### PR TITLE
tidy: Improve consistency and ordering of help text

### DIFF
--- a/src/anaconda_cli_base/cli.py
+++ b/src/anaconda_cli_base/cli.py
@@ -156,14 +156,14 @@ def main(
         help="Only show warnings or errors on the console",
         hidden=True,
     ),
+    version: Optional[bool] = typer.Option(
+        None, "-V", "--version", help="Show version and exit."
+    ),
     show_help: Optional[bool] = typer.Option(
         False,
         "-h",
         "--help",
         help="Show this message and exit.",
-    ),
-    version: Optional[bool] = typer.Option(
-        None, "-V", "--version", help="Show version and exit."
     ),
 ) -> None:
     """Anaconda CLI."""

--- a/src/anaconda_cli_base/cli.py
+++ b/src/anaconda_cli_base/cli.py
@@ -146,7 +146,7 @@ def main(
         False,
         "-v",
         "--verbose",
-        help="print debug information on the console",
+        help="Print debug information to the console.",
         hidden=False,
     ),
     quiet: Optional[bool] = typer.Option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,10 +30,19 @@ ENTRY_POINT_TUPLE = Tuple[str, str, typer.Typer]
         pytest.param(("-h",), id="-h"),
     ],
 )
-def test_cli_help(invoke_cli: CLIInvoker, args: Tuple[str]) -> None:
+@pytest.mark.parametrize(
+    "expected_text",
+    [
+        "Welcome to the Anaconda CLI!",
+        "Print debug information to the console.",
+        "Show this message and exit.",
+        "Show version and exit.",
+    ],
+)
+def test_cli_help(invoke_cli: CLIInvoker, args: Tuple[str], expected_text: str) -> None:
     result = invoke_cli(args)
     assert result.exit_code == 0
-    assert "Welcome to the Anaconda CLI!" in result.stdout
+    assert expected_text in result.stdout
 
 
 def test_cli_version(invoke_cli: CLIInvoker) -> None:


### PR DESCRIPTION
### Summary

* Changes the capitalization and wording of the `--verbose` option help to be consistent with the other options.
* Updates the ordering to make `--help` last and have the others alphabetical.

#### Before

<img width="948" alt="image" src="https://github.com/user-attachments/assets/fd0a6845-7d5e-4a64-873f-f17cdb6c7535" />

#### After

<img width="950" alt="image" src="https://github.com/user-attachments/assets/faab26ea-2744-47ef-a0f6-70fe154d2853" />
