### PR TITLE
chore: Update workflows to release to dev label on merges to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: release
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: release
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
-name: "release"
+name: release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
 
@@ -12,7 +14,6 @@ jobs:
   publish-conda-pkg-to-anaconda-dot-org:
     name: Publish conda package to Anaconda.org
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'  # Only run on push to main branch
     needs: [test]
     steps:
     - name: Retrieve the source code
@@ -26,13 +27,14 @@ jobs:
     - name: Download the build artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: anaconda-cli-base-conda-${{ github.sha }}
-        path: ~/anaconda-cli-base-conda-bld
+        name: conda-${{ github.sha }}
+        path: ./conda-bld
     - name: publish
       env:
         TOKEN: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
       run: |
         source $CONDA/bin/activate && conda activate build
+        # If it's not a tagged release, publish to dev label
         [[ "$GITHUB_REF" =~ ^refs/tags/v ]] || export LABEL="--label dev"
         anaconda --verbose \
           --token $TOKEN \
@@ -40,12 +42,11 @@ jobs:
           --user anaconda-cloud \
           $LABEL \
           --force \
-          ~/anaconda-cli-base-conda-bld/noarch/anaconda-cli-base-*
+          ./conda-bld/noarch/anaconda-*
 
   publish-wheel-to-anaconda-dot-org:
     name: Publish wheel to Anaconda.org
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'  # Only run on push to main branch
     needs: [test]
     steps:
     - name: Retrieve the source code
@@ -55,8 +56,8 @@ jobs:
     - name: Download the build artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: anaconda-cli-base-wheel-${{ github.sha }}
-        path: ~/dist
+        name: wheel-${{ github.sha }}
+        path: ./dist
     - name: Create build environment
       run: |
         source $CONDA/bin/activate
@@ -67,19 +68,19 @@ jobs:
         GITHUB_REF: ${{ github.ref }}
       run: |
         source $CONDA/bin/activate && conda activate build
+        # If it's not a tagged release, publish to dev label
         [[ "$GITHUB_REF" =~ ^refs/tags/v ]] || export LABEL="--label dev"
         anaconda --verbose \
           --token $TOKEN \
           upload \
           --user anaconda-cloud \
-          ~/dist/*.whl \
-          --summary \
-          "A base CLI entrypoint supporting Anaconda CLI plugins" \
           $LABEL \
           --force \
+          ./dist/*.whl
 
   publish-to-pypi:
     name: Build & publish to PyPI
+    # Only publish to PyPI if a tagged release
     if: startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: [test]
@@ -91,8 +92,8 @@ jobs:
     - name: Download the build artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: anaconda-cli-base-wheel-${{ github.sha }}
-        path: ~/dist
+        name: wheel-${{ github.sha }}
+        path: ./dist
     - name: Create build environment
       run: |
         source $CONDA/bin/activate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: "test"
+name: test
 
 on:
   pull_request:
@@ -24,7 +24,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install testing dependencies
-        run: python -m pip install tox tox-gh-actions
+        run: |
+          python -m pip install tox tox-gh-actions
       - name: Test with tox
         run: tox
 
@@ -47,7 +48,7 @@ jobs:
         - name: Upload the build artifact
           uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
           with:
-            name: anaconda-cli-base-conda-${{ github.sha }}
+            name: conda-${{ github.sha }}
             path: ./conda-bld
             if-no-files-found: error
             retention-days: 7
@@ -71,7 +72,7 @@ jobs:
       - name: Upload the build artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: anaconda-cli-base-wheel-${{ github.sha }}
+          name: wheel-${{ github.sha }}
           path: dist/*
           if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
The release pipeline was only configured to release for tagged releases. This PR updates it to push releases to the `dev` label of the `anaconda-cloud` channel for each merge into `main` branch.

I've also updated the names of the conda-package and wheel artifacts to be more generic so we can use the same workflow across differently-named packages.