### PR TITLE
[chore] anaconda.com and anaconda.org auth aliases

### DIFF
--- a/src/anaconda_cli_base/cli.py
+++ b/src/anaconda_cli_base/cli.py
@@ -184,7 +184,7 @@ def main(
         raise typer.Exit()
 
 
-def _load_auth_handlers(auth_handlers: Dict[str, typer.Typer]) -> None:
+def _load_auth_handlers(auth_handlers: Dict[str, typer.Typer], auth_handlers_dropdown: List[str]) -> None:
     def validate_at(ctx: typer.Context, _: Any, choice: str) -> str:
         show_help = ctx.params.get("help", False) is True
         if show_help:
@@ -193,11 +193,11 @@ def _load_auth_handlers(auth_handlers: Dict[str, typer.Typer]) -> None:
             raise typer.Exit()
 
         if choice is None:
-            choice = select_from_list("choose destination:", list(auth_handlers))
+            choice = select_from_list("choose destination:", auth_handlers_dropdown)
 
         elif choice not in auth_handlers:
             print(
-                f"{choice} is not an allowed value for --at. Use one of {list(auth_handlers)}"
+                f"{choice} is not an allowed value for --at. Use one of {auth_handlers_dropdown}"
             )
             raise typer.Abort()
         return choice
@@ -205,7 +205,7 @@ def _load_auth_handlers(auth_handlers: Dict[str, typer.Typer]) -> None:
     def _action(
         ctx: typer.Context,
         at: str = typer.Option(
-            None, callback=validate_at, help=f"Choose from {list(auth_handlers)}"
+            None, callback=validate_at, help=f"Choose from {auth_handlers_dropdown}"
         ),
         help: bool = typer.Option(False, "--help"),
     ) -> None:

--- a/src/anaconda_cli_base/plugins.py
+++ b/src/anaconda_cli_base/plugins.py
@@ -50,7 +50,8 @@ def load_registered_subcommands(app: Typer) -> None:
 
         if "login" in [cmd.name for cmd in subcommand_app.registered_commands]:
             auth_handlers[name] = subcommand_app
-            auth_handlers[AUTH_HANDLER_ALIASES[name]] = subcommand_app
+            alias = AUTH_HANDLER_ALIASES.get(name, name)
+            auth_handlers[alias] = subcommand_app
 
         app.add_typer(subcommand_app, name=name, rich_help_panel="Plugins")
 

--- a/src/anaconda_cli_base/plugins.py
+++ b/src/anaconda_cli_base/plugins.py
@@ -33,6 +33,12 @@ def _load_entry_points_for_group(group: str) -> List[Tuple[str, str, Typer]]:
     return loaded
 
 
+AUTH_HANDLER_ALIASES = {
+    "cloud": "anaconda.com",
+    "org": "anaconda.org"
+}
+
+
 def load_registered_subcommands(app: Typer) -> None:
     """Load all subcommands from plugins."""
     subcommand_entry_points = _load_entry_points_for_group(PLUGIN_GROUP_NAME)
@@ -44,11 +50,17 @@ def load_registered_subcommands(app: Typer) -> None:
 
         if "login" in [cmd.name for cmd in subcommand_app.registered_commands]:
             auth_handlers[name] = subcommand_app
+            auth_handlers[AUTH_HANDLER_ALIASES[name]] = subcommand_app
 
         app.add_typer(subcommand_app, name=name, rich_help_panel="Plugins")
 
     if auth_handlers:
-        app._load_auth_handlers(auth_handlers)  # type: ignore
+        auth_handlers_dropdown = sorted(list(AUTH_HANDLER_ALIASES.values()))
+        app._load_auth_handlers(  # type: ignore
+            auth_handlers=auth_handlers,
+            auth_handlers_dropdown=auth_handlers_dropdown
+        )
+
 
         log.debug(
             "Loaded subcommand '%s' from '%s'",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -185,7 +185,15 @@ def test_load_cloud_plugin(
     assert result.exit_code == 0
     assert result.stdout == "cloud: You're in\n"
 
+    result = invoke_cli(["login", "--at", "anaconda.com"])
+    assert result.exit_code == 0
+    assert result.stdout == "cloud: You're in\n"
+
     result = invoke_cli(["login", "--at", "cloud", "--help"])
+    assert result.exit_code == 0
+    assert "--force" in result.stdout
+
+    result = invoke_cli(["login", "--at", "anaconda.com", "--help"])
     assert result.exit_code == 0
     assert "--force" in result.stdout
 
@@ -357,6 +365,14 @@ def test_org_subcommand(
     assert result.exit_code == 0
     assert "org: done\n" == result.stdout
 
+    result = invoke_cli(["login", "--at", "org"])
+    assert result.exit_code == 0
+    assert result.stdout == "org: You're in\n"
+
+    result = invoke_cli(["login", "--at", "anaconda.org"])
+    assert result.exit_code == 0
+    assert result.stdout == "org: You're in\n"
+
 
 def test_login_select(
     invoke_cli: CLIInvoker,
@@ -377,17 +393,20 @@ def test_login_select(
     )
     load_registered_subcommands(cast(typer.Typer, anaconda_cli_base.cli.app))
 
-    result = invoke_cli(["login"], input="\n")
-    assert result.exit_code == 0
-    assert result.stdout.strip().splitlines()[-1].endswith("org: You're in")
+    result = invoke_cli(["login"])
+    assert result.stdout.strip().startswith("choose destination: \n * anaconda.com      \n   anaconda.org")
 
-    result = invoke_cli(["login"], input="j\n")
+    result = invoke_cli(["login"], input="\n")
     assert result.exit_code == 0
     assert result.stdout.strip().splitlines()[-1].endswith("cloud: You're in")
 
-    result = invoke_cli(["login"], input="jk\n")
+    result = invoke_cli(["login"], input="j\n")
     assert result.exit_code == 0
     assert result.stdout.strip().splitlines()[-1].endswith("org: You're in")
+
+    result = invoke_cli(["login"], input="jk\n")
+    assert result.exit_code == 0
+    assert result.stdout.strip().splitlines()[-1].endswith("cloud: You're in")
 
     # These cannot be tested because key.UP and key.DOWN send multiple characters
     # through to click.getchar, but that does not happen interactively.


### PR DESCRIPTION
This provides a quick hard-coded set of aliases for the `anaconda <auth-cmd> --at ...` commands: login, logout, whoami.

Only the new aliases `anaconda.com` and `anaconda.org` will be shown in the pulldown. If a new plugin defines auth commands but does not have an alias here the original entrypoint name is used.

In addition to the new aliases the `--at` flag will support original entrypoint names and aliases.