### PR TITLE
fix: Artifact path for wheel upload to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Upload to PyPI with twine
       run: |
         source $CONDA/bin/activate && conda activate build
-        twine upload ~/dist/*
+        twine upload ./dist/*
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
The upload path was updated for the `anaconda upload` command, but not for the `twine upload` command. This fixes publishing of the wheel to PyPI.