### PR TITLE
tidy: Update step name to reflect publish-only nature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           ./dist/*.whl
 
   publish-to-pypi:
-    name: Build & publish to PyPI
+    name: Publish to PyPI
     # Only publish to PyPI if a tagged release
     if: startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates the name to "Publish to PyPI", which better reflects the move of the build process to the `test.yml` workflow.