### PR TITLE
fix: Hide "auth" from the login dropdown list

### DIFF
--- a/src/anaconda_cli_base/plugins.py
+++ b/src/anaconda_cli_base/plugins.py
@@ -37,10 +37,7 @@ def _load_entry_points_for_group(group: str) -> List[Tuple[str, str, Typer]]:
     return loaded
 
 
-AUTH_HANDLER_ALIASES = {
-    "cloud": "anaconda.com",
-    "org": "anaconda.org"
-}
+AUTH_HANDLER_ALIASES = {"cloud": "anaconda.com", "org": "anaconda.org"}
 
 
 def load_registered_subcommands(app: Typer) -> None:
@@ -59,9 +56,8 @@ def load_registered_subcommands(app: Typer) -> None:
             if alias:
                 auth_handlers[alias] = subcommand_app
                 auth_handler_selectors.append(alias)
-            else:
+            elif name != "auth":
                 auth_handler_selectors.append(name)
-
 
         app.add_typer(subcommand_app, name=name, rich_help_panel="Plugins")
 

--- a/src/anaconda_cli_base/plugins.py
+++ b/src/anaconda_cli_base/plugins.py
@@ -37,7 +37,10 @@ def _load_entry_points_for_group(group: str) -> List[Tuple[str, str, Typer]]:
     return loaded
 
 
-AUTH_HANDLER_ALIASES = {"cloud": "anaconda.com", "org": "anaconda.org"}
+AUTH_HANDLER_ALIASES = {
+    "cloud": "anaconda.com",
+    "org": "anaconda.org",
+}
 
 
 def load_registered_subcommands(app: Typer) -> None:
@@ -56,8 +59,6 @@ def load_registered_subcommands(app: Typer) -> None:
             if alias:
                 auth_handlers[alias] = subcommand_app
                 auth_handler_selectors.append(alias)
-            elif name != "auth":
-                auth_handler_selectors.append(name)
 
         app.add_typer(subcommand_app, name=name, rich_help_panel="Plugins")
 


### PR DESCRIPTION
The existing logic will show aliases for `org` and `cloud`, but will show `auth`. This PR explicitly hides the name of the upcoming auth plugin.