### PR TITLE
feat: Add support for deprecating functionality

### DIFF
--- a/src/anaconda_cli_base/deprecations.py
+++ b/src/anaconda_cli_base/deprecations.py
@@ -13,7 +13,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
-    from typing import Any, Callable, ParamSpec, Self, TypeVar
+    from typing import Any, Callable, TypeVar
+    from typing_extensions import ParamSpec, Self
 
     from packaging.version import Version
 
@@ -365,7 +366,8 @@ class DeprecationHandler:
             else:
                 for loaded in sys.modules.values():
                     if not isinstance(loaded, ModuleType):
-                        continue
+                        # sys.modules typed as Iterable of ModuleType
+                        continue  # type: ignore
                     if not hasattr(loaded, "__file__"):
                         continue
                     if loaded.__file__ == filename:

--- a/src/anaconda_cli_base/deprecations.py
+++ b/src/anaconda_cli_base/deprecations.py
@@ -1,6 +1,12 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""Reusable helpers for deprecating functionality."""
+"""
+Reusable helpers for deprecating functionality.
+
+Note: most of this file has been copied from conda's implementation. Usage
+documentation can be found here: https://docs.conda.io/projects/conda/en/latest/dev-guide/deprecations.html
+
+"""
 
 from __future__ import annotations
 

--- a/src/anaconda_cli_base/deprecations.py
+++ b/src/anaconda_cli_base/deprecations.py
@@ -40,7 +40,9 @@ class DeprecationHandler:
     def __init__(self: Self, version: str) -> None:
         """Factory to create a deprecation handle for the specified version.
 
-        :param version: The version to compare against when checking deprecation statuses.
+        Args:
+            version: The version to compare against when checking deprecation statuses.
+
         """
         self._version = version
         # Try to parse the version string as a simple tuple[int, ...] to avoid
@@ -52,7 +54,9 @@ class DeprecationHandler:
     def _get_version_tuple(version: str) -> tuple[int, ...] | None:
         """Return version as non-empty tuple of ints if possible, else None.
 
-        :param version: Version string to parse.
+        Args:
+            version: Version string to parse.
+
         """
         try:
             return tuple(int(part) for part in version.strip().split(".")) or None
@@ -62,7 +66,9 @@ class DeprecationHandler:
     def _version_less_than(self: Self, version: str) -> bool:
         """Test whether own version is less than the given version.
 
-        :param version: Version string to compare against.
+        Args:
+            version: Version string to compare against.
+
         """
         if self._version_tuple and (version_tuple := self._get_version_tuple(version)):
             return self._version_tuple < version_tuple
@@ -90,10 +96,12 @@ class DeprecationHandler:
     ) -> Callable[[Callable[P, T]], Callable[P, T]]:
         """Deprecation decorator for functions, methods, & classes.
 
-        :param deprecate_in: Version in which code will be marked as deprecated.
-        :param remove_in: Version in which code is expected to be removed.
-        :param addendum: Optional additional messaging. Useful to indicate what to do instead.
-        :param stack: Optional stacklevel increment.
+        Args:
+            deprecate_in: Version in which code will be marked as deprecated.
+            remove_in: Version in which code is expected to be removed.
+            addendum: Optional additional messaging. Useful to indicate what to do instead.
+            stack: Optional stacklevel increment.
+
         """
 
         def deprecated_decorator(func: Callable[P, T]) -> Callable[P, T]:
@@ -132,12 +140,14 @@ class DeprecationHandler:
     ) -> Callable[[Callable[P, T]], Callable[P, T]]:
         """Deprecation decorator for keyword arguments.
 
-        :param deprecate_in: Version in which code will be marked as deprecated.
-        :param remove_in: Version in which code is expected to be removed.
-        :param argument: The argument to deprecate.
-        :param rename: Optional new argument name.
-        :param addendum: Optional additional messaging. Useful to indicate what to do instead.
-        :param stack: Optional stacklevel increment.
+        Args:
+            deprecate_in: Version in which code will be marked as deprecated.
+            remove_in: Version in which code is expected to be removed.
+            argument: The argument to deprecate.
+            rename: Optional new argument name.
+            addendum: Optional additional messaging. Useful to indicate what to do instead.
+            stack: Optional stacklevel increment.
+
         """
 
         def deprecated_decorator(func: Callable[P, T]) -> Callable[P, T]:
@@ -242,10 +252,12 @@ class DeprecationHandler:
     ) -> None:
         """Deprecation function for modules.
 
-        :param deprecate_in: Version in which code will be marked as deprecated.
-        :param remove_in: Version in which code is expected to be removed.
-        :param addendum: Optional additional messaging. Useful to indicate what to do instead.
-        :param stack: Optional stacklevel increment.
+        Args:
+            deprecate_in: Version in which code will be marked as deprecated.
+            remove_in: Version in which code is expected to be removed.
+            addendum: Optional additional messaging. Useful to indicate what to do instead.
+            stack: Optional stacklevel increment.
+
         """
         self.topic(
             deprecate_in=deprecate_in,
@@ -267,12 +279,14 @@ class DeprecationHandler:
     ) -> None:
         """Deprecation function for module constant/global.
 
-        :param deprecate_in: Version in which code will be marked as deprecated.
-        :param remove_in: Version in which code is expected to be removed.
-        :param constant:
-        :param value:
-        :param addendum: Optional additional messaging. Useful to indicate what to do instead.
-        :param stack: Optional stacklevel increment.
+        Args:
+            deprecate_in: Version in which code will be marked as deprecated.
+            remove_in: Version in which code is expected to be removed.
+            constant:
+            value:
+            addendum: Optional additional messaging. Useful to indicate what to do instead.
+            stack: Optional stacklevel increment.
+
         """
         # detect calling module
         module, fullname = self._get_module(stack)
@@ -314,11 +328,13 @@ class DeprecationHandler:
     ) -> None:
         """Deprecation function for a topic.
 
-        :param deprecate_in: Version in which code will be marked as deprecated.
-        :param remove_in: Version in which code is expected to be removed.
-        :param topic: The topic being deprecated.
-        :param addendum: Optional additional messaging. Useful to indicate what to do instead.
-        :param stack: Optional stacklevel increment.
+        Args:
+            deprecate_in: Version in which code will be marked as deprecated.
+            remove_in: Version in which code is expected to be removed.
+            topic: The topic being deprecated.
+            addendum: Optional additional messaging. Useful to indicate what to do instead.
+            stack: Optional stacklevel increment.
+
         """
         # detect function name and generate message
         category, message = self._generate_message(
@@ -338,8 +354,12 @@ class DeprecationHandler:
     def _get_module(self: Self, stack: int) -> tuple[ModuleType, str]:
         """Detect the module from which we are being called.
 
-        :param stack: The stacklevel increment.
-        :return: The module and module name.
+        Args:
+            stack: The stacklevel increment.
+
+        Returns:
+            The module and module name.
+
         """
         try:
             frame = sys._getframe(2 + stack)
@@ -384,12 +404,16 @@ class DeprecationHandler:
         """Generate the standardized deprecation message and determine whether the
         deprecation is pending, active, or past.
 
-        :param deprecate_in: Version in which code will be marked as deprecated.
-        :param remove_in: Version in which code is expected to be removed.
-        :param prefix: The message prefix, usually the function name.
-        :param addendum: Additional messaging. Useful to indicate what to do instead.
-        :param deprecation_type: The warning type to use for active deprecations.
-        :return: The warning category (if applicable) and the message.
+        Args:
+            deprecate_in: Version in which code will be marked as deprecated.
+            remove_in: Version in which code is expected to be removed.
+            prefix: The message prefix, usually the function name.
+            addendum: Additional messaging. Useful to indicate what to do instead.
+            deprecation_type: The warning type to use for active deprecations.
+
+        Returns:
+            The warning category (if applicable) and the message.
+
         """
         category: type[Warning] | None
         if self._version_less_than(deprecate_in):

--- a/src/anaconda_cli_base/deprecations.py
+++ b/src/anaconda_cli_base/deprecations.py
@@ -23,17 +23,7 @@ if TYPE_CHECKING:
 
     ActionType = TypeVar("ActionType", bound=type[Action])
 
-from . import __version__
-
-
-DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED = " ".join(
-    [
-        "The Projects, Notebooks, and Environments features have been removed.",
-        "See our release notes (https://docs.anaconda.com/anacondaorg/release-notes/)",
-        "for more information.",
-        "If you have any questions, please contact usercare@anaconda.com.",
-    ]
-)
+from anaconda_cli_base import __version__
 
 
 class DeprecatedError(RuntimeError):

--- a/src/anaconda_cli_base/deprecations.py
+++ b/src/anaconda_cli_base/deprecations.py
@@ -418,4 +418,4 @@ class DeprecationHandler:
         )
 
 
-deprecated = DeprecationHandler(__version__)
+deprecated: DeprecationHandler = DeprecationHandler(__version__)

--- a/src/anaconda_cli_base/deprecations.py
+++ b/src/anaconda_cli_base/deprecations.py
@@ -11,6 +11,8 @@ from functools import wraps
 from types import ModuleType
 from typing import TYPE_CHECKING
 
+from anaconda_cli_base import __version__
+
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Any, Callable, TypeVar
@@ -22,8 +24,6 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
     ActionType = TypeVar("ActionType", bound=type[Action])
-
-from anaconda_cli_base import __version__
 
 
 class DeprecatedError(RuntimeError):

--- a/src/anaconda_cli_base/deprecations.py
+++ b/src/anaconda_cli_base/deprecations.py
@@ -1,0 +1,419 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Reusable helpers for deprecating functionality."""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from argparse import Action
+from functools import wraps
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+    from typing import Any, Callable, ParamSpec, Self, TypeVar
+
+    from packaging.version import Version
+
+    T = TypeVar("T")
+    P = ParamSpec("P")
+
+    ActionType = TypeVar("ActionType", bound=type[Action])
+
+from . import __version__
+
+
+DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED = " ".join(
+    [
+        "The Projects, Notebooks, and Environments features have been removed.",
+        "See our release notes (https://docs.anaconda.com/anacondaorg/release-notes/)",
+        "for more information.",
+        "If you have any questions, please contact usercare@anaconda.com.",
+    ]
+)
+
+
+class DeprecatedError(RuntimeError):
+    pass
+
+
+# inspired by deprecation (https://deprecation.readthedocs.io/en/latest/) and
+# CPython's warnings._deprecated
+class DeprecationHandler:
+    _version: str | None
+    _version_tuple: tuple[int, ...] | None
+    _version_object: Version | None
+
+    def __init__(self: Self, version: str) -> None:
+        """Factory to create a deprecation handle for the specified version.
+
+        :param version: The version to compare against when checking deprecation statuses.
+        """
+        self._version = version
+        # Try to parse the version string as a simple tuple[int, ...] to avoid
+        # packaging.version import and costlier version comparisons.
+        self._version_tuple = self._get_version_tuple(version)
+        self._version_object = None
+
+    @staticmethod
+    def _get_version_tuple(version: str) -> tuple[int, ...] | None:
+        """Return version as non-empty tuple of ints if possible, else None.
+
+        :param version: Version string to parse.
+        """
+        try:
+            return tuple(int(part) for part in version.strip().split(".")) or None
+        except (AttributeError, ValueError):
+            return None
+
+    def _version_less_than(self: Self, version: str) -> bool:
+        """Test whether own version is less than the given version.
+
+        :param version: Version string to compare against.
+        """
+        if self._version_tuple and (version_tuple := self._get_version_tuple(version)):
+            return self._version_tuple < version_tuple
+
+        # If self._version or version could not be represented by a simple
+        # tuple[int, ...], do a more elaborate version parsing and comparison.
+        # Avoid this import otherwise to reduce import time for conda activate.
+        from packaging.version import parse
+
+        if self._version_object is None:
+            try:
+                self._version_object = parse(self._version)  # type: ignore[arg-type]
+            except TypeError:
+                # TypeError: self._version could not be parsed
+                self._version_object = parse("0.0.0.dev0+placeholder")
+        return self._version_object < parse(version)
+
+    def __call__(
+        self: Self,
+        deprecate_in: str,
+        remove_in: str,
+        *,
+        addendum: str | None = None,
+        stack: int = 0,
+    ) -> Callable[[Callable[P, T]], Callable[P, T]]:
+        """Deprecation decorator for functions, methods, & classes.
+
+        :param deprecate_in: Version in which code will be marked as deprecated.
+        :param remove_in: Version in which code is expected to be removed.
+        :param addendum: Optional additional messaging. Useful to indicate what to do instead.
+        :param stack: Optional stacklevel increment.
+        """
+
+        def deprecated_decorator(func: Callable[P, T]) -> Callable[P, T]:
+            # detect function name and generate message
+            category, message = self._generate_message(
+                deprecate_in=deprecate_in,
+                remove_in=remove_in,
+                prefix=f"{func.__module__}.{func.__qualname__}",
+                addendum=addendum,
+            )
+
+            # alert developer that it's time to remove something
+            if not category:
+                raise DeprecatedError(message)
+
+            # alert user that it's time to remove something
+            @wraps(func)
+            def inner(*args: P.args, **kwargs: P.kwargs) -> T:
+                warnings.warn(message, category, stacklevel=2 + stack)
+
+                return func(*args, **kwargs)
+
+            return inner
+
+        return deprecated_decorator
+
+    def argument(
+        self: Self,
+        deprecate_in: str,
+        remove_in: str,
+        argument: str,
+        *,
+        rename: str | None = None,
+        addendum: str | None = None,
+        stack: int = 0,
+    ) -> Callable[[Callable[P, T]], Callable[P, T]]:
+        """Deprecation decorator for keyword arguments.
+
+        :param deprecate_in: Version in which code will be marked as deprecated.
+        :param remove_in: Version in which code is expected to be removed.
+        :param argument: The argument to deprecate.
+        :param rename: Optional new argument name.
+        :param addendum: Optional additional messaging. Useful to indicate what to do instead.
+        :param stack: Optional stacklevel increment.
+        """
+
+        def deprecated_decorator(func: Callable[P, T]) -> Callable[P, T]:
+            # detect function name and generate message
+            category, message = self._generate_message(
+                deprecate_in=deprecate_in,
+                remove_in=remove_in,
+                prefix=f"{func.__module__}.{func.__qualname__}({argument})",
+                # provide a default addendum if renaming and no addendum is provided
+                addendum=(
+                    f"Use '{rename}' instead." if rename and not addendum else addendum
+                ),
+            )
+
+            # alert developer that it's time to remove something
+            if not category:
+                raise DeprecatedError(message)
+
+            # alert user that it's time to remove something
+            @wraps(func)
+            def inner(*args: P.args, **kwargs: P.kwargs) -> T:
+                # only warn about argument deprecations if the argument is used
+                if argument in kwargs:
+                    warnings.warn(message, category, stacklevel=2 + stack)
+
+                    # rename argument deprecations as needed
+                    value = kwargs.pop(argument, None)
+                    if rename:
+                        kwargs.setdefault(rename, value)
+
+                return func(*args, **kwargs)
+
+            return inner
+
+        return deprecated_decorator
+
+    def action(
+        self: Self,
+        deprecate_in: str,
+        remove_in: str,
+        action: ActionType,
+        *,
+        addendum: str | None = None,
+        stack: int = 0,
+    ) -> ActionType:
+        """Wraps any argparse.Action to issue a deprecation warning."""
+
+        class DeprecationMixin(Action):
+            category: type[Warning]
+            help: str  # override argparse.Action's help type annotation
+
+            def __init__(inner_self: Self, *args: Any, **kwargs: Any) -> None:
+                super().__init__(*args, **kwargs)
+
+                category, message = self._generate_message(
+                    deprecate_in=deprecate_in,
+                    remove_in=remove_in,
+                    prefix=(
+                        # option_string are ordered shortest to longest,
+                        # use the longest as it's the most descriptive
+                        f"`{inner_self.option_strings[-1]}`"
+                        if inner_self.option_strings
+                        # if not a flag/switch, use the destination itself
+                        else f"`{inner_self.dest}`"
+                    ),
+                    addendum=addendum,
+                    deprecation_type=FutureWarning,
+                )
+
+                # alert developer that it's time to remove something
+                if not category:
+                    raise DeprecatedError(message)
+
+                inner_self.category = category
+                inner_self.help = message
+
+            def __call__(
+                inner_self: Self,
+                parser: ArgumentParser,
+                namespace: Namespace,
+                values: Any,
+                option_string: str | None = None,
+            ) -> None:
+                # alert user that it's time to remove something
+                warnings.warn(
+                    inner_self.help,
+                    inner_self.category,
+                    stacklevel=7 + stack,
+                )
+
+                super().__call__(parser, namespace, values, option_string)
+
+        return type(action.__name__, (DeprecationMixin, action), {})  # type: ignore[return-value]
+
+    def module(
+        self: Self,
+        deprecate_in: str,
+        remove_in: str,
+        *,
+        addendum: str | None = None,
+        stack: int = 0,
+    ) -> None:
+        """Deprecation function for modules.
+
+        :param deprecate_in: Version in which code will be marked as deprecated.
+        :param remove_in: Version in which code is expected to be removed.
+        :param addendum: Optional additional messaging. Useful to indicate what to do instead.
+        :param stack: Optional stacklevel increment.
+        """
+        self.topic(
+            deprecate_in=deprecate_in,
+            remove_in=remove_in,
+            topic=self._get_module(stack)[1],
+            addendum=addendum,
+            stack=2 + stack,
+        )
+
+    def constant(
+        self: Self,
+        deprecate_in: str,
+        remove_in: str,
+        constant: str,
+        value: Any,
+        *,
+        addendum: str | None = None,
+        stack: int = 0,
+    ) -> None:
+        """Deprecation function for module constant/global.
+
+        :param deprecate_in: Version in which code will be marked as deprecated.
+        :param remove_in: Version in which code is expected to be removed.
+        :param constant:
+        :param value:
+        :param addendum: Optional additional messaging. Useful to indicate what to do instead.
+        :param stack: Optional stacklevel increment.
+        """
+        # detect calling module
+        module, fullname = self._get_module(stack)
+        # detect function name and generate message
+        category, message = self._generate_message(
+            deprecate_in=deprecate_in,
+            remove_in=remove_in,
+            prefix=f"{fullname}.{constant}",
+            addendum=addendum,
+        )
+
+        # alert developer that it's time to remove something
+        if not category:
+            raise DeprecatedError(message)
+
+        # patch module level __getattr__ to alert user that it's time to remove something
+        super_getattr = getattr(module, "__getattr__", None)
+
+        def __getattr__(name: str) -> Any:
+            if name == constant:
+                warnings.warn(message, category, stacklevel=2 + stack)
+                return value
+
+            if super_getattr:
+                return super_getattr(name)
+
+            raise AttributeError(f"module '{fullname}' has no attribute '{name}'")
+
+        module.__getattr__ = __getattr__  # type: ignore[method-assign]
+
+    def topic(
+        self: Self,
+        deprecate_in: str,
+        remove_in: str,
+        *,
+        topic: str,
+        addendum: str | None = None,
+        stack: int = 0,
+    ) -> None:
+        """Deprecation function for a topic.
+
+        :param deprecate_in: Version in which code will be marked as deprecated.
+        :param remove_in: Version in which code is expected to be removed.
+        :param topic: The topic being deprecated.
+        :param addendum: Optional additional messaging. Useful to indicate what to do instead.
+        :param stack: Optional stacklevel increment.
+        """
+        # detect function name and generate message
+        category, message = self._generate_message(
+            deprecate_in=deprecate_in,
+            remove_in=remove_in,
+            prefix=topic,
+            addendum=addendum,
+        )
+
+        # alert developer that it's time to remove something
+        if not category:
+            raise DeprecatedError(message)
+
+        # alert user that it's time to remove something
+        warnings.warn(message, category, stacklevel=2 + stack)
+
+    def _get_module(self: Self, stack: int) -> tuple[ModuleType, str]:
+        """Detect the module from which we are being called.
+
+        :param stack: The stacklevel increment.
+        :return: The module and module name.
+        """
+        try:
+            frame = sys._getframe(2 + stack)
+        except IndexError:
+            # IndexError: 2 + stack is out of range
+            pass
+        else:
+            # Shortcut finding the module by manually inspecting loaded modules.
+            try:
+                filename = frame.f_code.co_filename
+            except AttributeError:
+                # AttributeError: frame.f_code.co_filename is undefined
+                pass
+            else:
+                for loaded in sys.modules.values():
+                    if not isinstance(loaded, ModuleType):
+                        continue
+                    if not hasattr(loaded, "__file__"):
+                        continue
+                    if loaded.__file__ == filename:
+                        return (loaded, loaded.__name__)
+
+            # If above failed, do an expensive import and costly getmodule call.
+            import inspect
+
+            module = inspect.getmodule(frame)
+            if module is not None:
+                return (module, module.__name__)
+
+        raise DeprecatedError("unable to determine the calling module")
+
+    def _generate_message(
+        self: Self,
+        deprecate_in: str,
+        remove_in: str,
+        prefix: str,
+        addendum: str | None,
+        *,
+        deprecation_type: type[Warning] = DeprecationWarning,
+    ) -> tuple[type[Warning] | None, str]:
+        """Generate the standardized deprecation message and determine whether the
+        deprecation is pending, active, or past.
+
+        :param deprecate_in: Version in which code will be marked as deprecated.
+        :param remove_in: Version in which code is expected to be removed.
+        :param prefix: The message prefix, usually the function name.
+        :param addendum: Additional messaging. Useful to indicate what to do instead.
+        :param deprecation_type: The warning type to use for active deprecations.
+        :return: The warning category (if applicable) and the message.
+        """
+        category: type[Warning] | None
+        if self._version_less_than(deprecate_in):
+            category = PendingDeprecationWarning
+            warning = f"is pending deprecation and will be removed in {remove_in}."
+        elif self._version_less_than(remove_in):
+            category = deprecation_type
+            warning = f"is deprecated and will be removed in {remove_in}."
+        else:
+            category = None
+            warning = f"was slated for removal in {remove_in}."
+
+        return (
+            category,
+            " ".join(filter(None, [prefix, warning, addendum])),  # message
+        )
+
+
+deprecated = DeprecationHandler(__version__)

--- a/src/anaconda_cli_base/deprecations.py
+++ b/src/anaconda_cli_base/deprecations.py
@@ -69,7 +69,7 @@ class DeprecationHandler:
 
         # If self._version or version could not be represented by a simple
         # tuple[int, ...], do a more elaborate version parsing and comparison.
-        # Avoid this import otherwise to reduce import time for conda activate.
+        # Avoid this import otherwise to reduce import time.
         from packaging.version import parse
 
         if self._version_object is None:

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from argparse import ArgumentParser, _StoreTrueAction
 from contextlib import nullcontext
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -61,10 +61,10 @@ def test_function(
     with nullcontext() if warning else pytest.raises(DeprecatedError):
 
         @deprecated(deprecate_in="2.0", remove_in="3.0")
-        def foo():
+        def foo() -> bool:
             return True
 
-        with pytest.warns(warning, match=message):
+        with pytest.warns(warning, match=message):  # type: ignore
             assert foo()
 
 
@@ -79,10 +79,10 @@ def test_method(
 
         class Bar:
             @deprecated("2.0", "3.0")
-            def foo(self):
+            def foo(self) -> bool:
                 return True
 
-        with pytest.warns(warning, match=message):
+        with pytest.warns(warning, match=message):  # type: ignore
             assert Bar().foo()
 
 
@@ -99,7 +99,7 @@ def test_class(
         class Foo:
             pass
 
-        with pytest.warns(warning, match=message):
+        with pytest.warns(warning, match=message):  # type: ignore
             assert Foo()
 
 
@@ -113,7 +113,7 @@ def test_arguments(
     with nullcontext() if warning else pytest.raises(DeprecatedError):
 
         @deprecated.argument("2.0", "3.0", "three")
-        def foo(one, two):
+        def foo(one: Any, two: Any) -> bool:
             return True
 
         # too many arguments, can only deprecate keyword arguments
@@ -121,7 +121,7 @@ def test_arguments(
             assert foo(1, 2, 3)
 
         # alerting user to pending deprecation
-        with pytest.warns(warning, match=message):
+        with pytest.warns(warning, match=message):  # type: ignore
             assert foo(1, 2, three=3)
 
         # normal usage not needing deprecation
@@ -142,7 +142,7 @@ def test_action(
             action=deprecated.action("2.0", "3.0", _StoreTrueAction),
         )
 
-        with pytest.warns(warning, match=message):
+        with pytest.warns(warning, match=message):  # type: ignore
             parser.parse_args(["--foo"])
 
 
@@ -153,11 +153,12 @@ def test_module(
     message: str | None,
 ) -> None:
     """Importing a deprecated module displays associated warning (or error)."""
-    with (
+    context = (
         pytest.warns(warning, match=message)
         if warning
         else pytest.raises(DeprecatedError)
-    ):
+    )
+    with context:
         deprecated.module("2.0", "3.0")
 
 
@@ -172,7 +173,7 @@ def test_constant(
         deprecated.constant("2.0", "3.0", "SOME_CONSTANT", 42)
         module = sys.modules[__name__]
 
-        with pytest.warns(warning, match=message):
+        with pytest.warns(warning, match=message):  # type: ignore
             module.SOME_CONSTANT
 
 
@@ -183,11 +184,12 @@ def test_topic(
     message: str | None,
 ) -> None:
     """Reaching a deprecated topic displays associated warning (or error)."""
-    with (
+    context = (
         pytest.warns(warning, match=message)
         if warning
         else pytest.raises(DeprecatedError)
-    ):
+    )
+    with context:
         deprecated.topic("2.0", "3.0", topic="Some special topic")
 
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -9,12 +9,12 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from binstar_client.deprecations import DeprecatedError, DeprecationHandler
+from anaconda_cli_base.deprecations import DeprecatedError, DeprecationHandler
 
 if TYPE_CHECKING:
     from packaging.version import Version
 
-    from binstar_client.deprecations import DevDeprecationType, UserDeprecationType
+    from anaconda_cli_base.deprecations import DevDeprecationType, UserDeprecationType
 
 PENDING = pytest.param(
     DeprecationHandler("1.0"),  # deprecated

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,200 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import sys
+from argparse import ArgumentParser, _StoreTrueAction
+from contextlib import nullcontext
+from typing import TYPE_CHECKING
+
+import pytest
+
+from binstar_client.deprecations import DeprecatedError, DeprecationHandler
+
+if TYPE_CHECKING:
+    from packaging.version import Version
+
+    from binstar_client.deprecations import DevDeprecationType, UserDeprecationType
+
+PENDING = pytest.param(
+    DeprecationHandler("1.0"),  # deprecated
+    PendingDeprecationWarning,  # warning
+    "pending deprecation",  # message
+    id="pending",
+)
+FUTURE = pytest.param(
+    DeprecationHandler("2.0"),  # deprecated
+    FutureWarning,  # warning
+    "deprecated",  # message
+    id="future",
+)
+DEPRECATED = pytest.param(
+    DeprecationHandler("2.0"),  # deprecated
+    DeprecationWarning,  # warning
+    "deprecated",  # message
+    id="deprecated",
+)
+REMOVE = pytest.param(
+    DeprecationHandler("3.0"),  # deprecated
+    None,  # warning
+    None,  # message
+    id="remove",
+)
+
+parametrize_user = pytest.mark.parametrize(
+    "deprecated,warning,message",
+    [PENDING, FUTURE, REMOVE],
+)
+parametrize_dev = pytest.mark.parametrize(
+    "deprecated,warning,message",
+    [PENDING, DEPRECATED, REMOVE],
+)
+
+
+@parametrize_dev
+def test_function(
+    deprecated: DeprecationHandler,
+    warning: DevDeprecationType | None,
+    message: str | None,
+) -> None:
+    """Calling a deprecated function displays associated warning (or error)."""
+    with nullcontext() if warning else pytest.raises(DeprecatedError):
+
+        @deprecated(deprecate_in="2.0", remove_in="3.0")
+        def foo():
+            return True
+
+        with pytest.warns(warning, match=message):
+            assert foo()
+
+
+@parametrize_dev
+def test_method(
+    deprecated: DeprecationHandler,
+    warning: DevDeprecationType | None,
+    message: str | None,
+) -> None:
+    """Calling a deprecated method displays associated warning (or error)."""
+    with nullcontext() if warning else pytest.raises(DeprecatedError):
+
+        class Bar:
+            @deprecated("2.0", "3.0")
+            def foo(self):
+                return True
+
+        with pytest.warns(warning, match=message):
+            assert Bar().foo()
+
+
+@parametrize_dev
+def test_class(
+    deprecated: DeprecationHandler,
+    warning: DevDeprecationType | None,
+    message: str | None,
+) -> None:
+    """Calling a deprecated class displays associated warning (or error)."""
+    with nullcontext() if warning else pytest.raises(DeprecatedError):
+
+        @deprecated("2.0", "3.0")
+        class Foo:
+            pass
+
+        with pytest.warns(warning, match=message):
+            assert Foo()
+
+
+@parametrize_dev
+def test_arguments(
+    deprecated: DeprecationHandler,
+    warning: DevDeprecationType | None,
+    message: str | None,
+) -> None:
+    """Calling a deprecated argument displays associated warning (or error)."""
+    with nullcontext() if warning else pytest.raises(DeprecatedError):
+
+        @deprecated.argument("2.0", "3.0", "three")
+        def foo(one, two):
+            return True
+
+        # too many arguments, can only deprecate keyword arguments
+        with pytest.raises(TypeError):
+            assert foo(1, 2, 3)
+
+        # alerting user to pending deprecation
+        with pytest.warns(warning, match=message):
+            assert foo(1, 2, three=3)
+
+        # normal usage not needing deprecation
+        assert foo(1, 2)
+
+
+@parametrize_user
+def test_action(
+    deprecated: DeprecationHandler,
+    warning: UserDeprecationType | None,
+    message: str | None,
+) -> None:
+    """Calling a deprecated argparse.Action displays associated warning (or error)."""
+    with nullcontext() if warning else pytest.raises(DeprecatedError):
+        parser = ArgumentParser()
+        parser.add_argument(
+            "--foo",
+            action=deprecated.action("2.0", "3.0", _StoreTrueAction),
+        )
+
+        with pytest.warns(warning, match=message):
+            parser.parse_args(["--foo"])
+
+
+@parametrize_dev
+def test_module(
+    deprecated: DeprecationHandler,
+    warning: DevDeprecationType | None,
+    message: str | None,
+) -> None:
+    """Importing a deprecated module displays associated warning (or error)."""
+    with (
+        pytest.warns(warning, match=message)
+        if warning
+        else pytest.raises(DeprecatedError)
+    ):
+        deprecated.module("2.0", "3.0")
+
+
+@parametrize_dev
+def test_constant(
+    deprecated: DeprecationHandler,
+    warning: DevDeprecationType | None,
+    message: str | None,
+) -> None:
+    """Using a deprecated constant displays associated warning (or error)."""
+    with nullcontext() if warning else pytest.raises(DeprecatedError):
+        deprecated.constant("2.0", "3.0", "SOME_CONSTANT", 42)
+        module = sys.modules[__name__]
+
+        with pytest.warns(warning, match=message):
+            module.SOME_CONSTANT
+
+
+@parametrize_dev
+def test_topic(
+    deprecated: DeprecationHandler,
+    warning: DevDeprecationType | None,
+    message: str | None,
+) -> None:
+    """Reaching a deprecated topic displays associated warning (or error)."""
+    with (
+        pytest.warns(warning, match=message)
+        if warning
+        else pytest.raises(DeprecatedError)
+    ):
+        deprecated.topic("2.0", "3.0", topic="Some special topic")
+
+
+def test_version_fallback() -> None:
+    """Test that anaconda_client can run even if deprecations can't parse the version."""
+    deprecated = DeprecationHandler(None)  # type: ignore[arg-type]
+    assert deprecated._version_less_than("0")
+    assert deprecated._version_tuple is None
+    version: Version = deprecated._version_object  # type: ignore[assignment]
+    assert version.major == version.minor == version.micro == 0


### PR DESCRIPTION
This PR adds the same support for deprecations that `conda` has. By placing it in `anaconda-cli-base`, we can leverage it inside various plugins and other libraries to handle deprecation of certain functionality.

Each plugin can create their own instance of the `DeprecationHandler`, tied to its own specific version.