### PR TITLE
[chore] error handling in configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["hatchling", "hatch-vcs>=0.3", "setuptools-scm>=7.1"]
 [project]
 dependencies = [
   "rich",
-  "click",
+  "click <8.2",
   "readchar",
   "typer",
   "packaging >=23.0",

--- a/src/anaconda_cli_base/config.py
+++ b/src/anaconda_cli_base/config.py
@@ -15,6 +15,8 @@ from pydantic_settings import PydanticBaseSettingsSource
 from pydantic_settings import PyprojectTomlConfigSettingsSource
 from pydantic_settings import SettingsConfigDict
 
+from .exceptions import AnacondaConfigTomlSyntaxError, AnacondaConfigValidationError
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
@@ -29,14 +31,6 @@ def anaconda_config_path() -> Path:
             )
         )
     )
-
-
-class AnacondaConfigTomlSyntaxError(tomllib.TOMLDecodeError):
-    pass
-
-
-class AnacondaConfigValidationError(ValueError):
-    pass
 
 
 class AnacondaConfigTomlSettingsSource(PyprojectTomlConfigSettingsSource):

--- a/src/anaconda_cli_base/config.py
+++ b/src/anaconda_cli_base/config.py
@@ -93,7 +93,7 @@ class AnacondaBaseSettings(BaseSettings):
                 kwarg = error["loc"][0]
                 if kwarg in kwargs:
                     value = kwargs[kwarg]
-                    msg = f"- Error in {e.title}({error['loc'][0]}={value})\n    {msg}"
+                    msg = f"- Error in init kwarg {e.title}({error['loc'][0]}={value})\n    {msg}"
                 elif env_var in os.environ:
                     msg = f"- Error in environment variable {env_var}={input_value}\n    {msg}"
                 else:
@@ -103,7 +103,7 @@ class AnacondaBaseSettings(BaseSettings):
 
                 errors.append(msg)
 
-            message = "\n".join(errors)
+            message = "\n" + "\n".join(errors)
 
             raise AnacondaConfigValidationError(message)
 

--- a/src/anaconda_cli_base/config.py
+++ b/src/anaconda_cli_base/config.py
@@ -74,7 +74,7 @@ class AnacondaBaseSettings(BaseSettings):
 
         return super().__init_subclass__(**kwargs)
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         try:
             super().__init__(**kwargs)
         except ValidationError as e:
@@ -83,10 +83,13 @@ class AnacondaBaseSettings(BaseSettings):
                 input_value = error["input"]
                 msg = error["msg"]
 
-                env_var = self.model_config.get("env_prefix", "") + self.model_config.get("env_nested_delimiter", "").join(str(l).upper() for l in error["loc"])
+                env_prefix = self.model_config.get("env_prefix", "")
+                delimiter = self.model_config.get("env_nested_delimiter", "") or ""
+                env_var = env_prefix + delimiter.join(str(l).upper() for l in error["loc"])
+
                 kwarg = error["loc"][0]
                 if kwarg in kwargs:
-                    value = kwargs[kwarg]
+                    value = kwargs[str(kwarg)]
                     msg = f"- Error in init kwarg {e.title}({error['loc'][0]}={value})\n    {msg}"
                 elif env_var in os.environ:
                     msg = f"- Error in environment variable {env_var}={input_value}\n    {msg}"

--- a/src/anaconda_cli_base/exceptions.py
+++ b/src/anaconda_cli_base/exceptions.py
@@ -1,9 +1,20 @@
+import sys
 from collections import defaultdict
 from typing import Callable, Dict, Type
 
 from anaconda_cli_base.console import console
 
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 ErrorHandlingCallback = Callable[[Exception], int]
+
+class AnacondaConfigTomlSyntaxError(tomllib.TOMLDecodeError): ...
+
+
+class AnacondaConfigValidationError(ValueError): ...
 
 
 def catch_all(e: Exception) -> int:

--- a/src/anaconda_cli_base/exceptions.py
+++ b/src/anaconda_cli_base/exceptions.py
@@ -7,7 +7,8 @@ ErrorHandlingCallback = Callable[[Exception], int]
 
 
 def catch_all(e: Exception) -> int:
-    console.print(f"[bold][red]{e.__class__.__name__}:[/bold][/red] {e}")
+    console.print(f"[bold][red]{e.__class__.__name__}:[/bold][/red] ", end="")
+    console.print(e, markup=False)
     return 1
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,8 +10,8 @@ from pytest_mock import MockerFixture
 
 import anaconda_cli_base.cli
 from anaconda_cli_base.config import AnacondaBaseSettings
-from anaconda_cli_base.config import AnacondaConfigTomlSyntaxError
-from anaconda_cli_base.config import AnacondaConfigValidationError
+from anaconda_cli_base.exceptions import AnacondaConfigTomlSyntaxError
+from anaconda_cli_base.exceptions import AnacondaConfigValidationError
 from anaconda_cli_base.plugins import load_registered_subcommands
 
 from .conftest import CLIInvoker

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,17 +1,23 @@
 from pathlib import Path
 from textwrap import dedent
-from typing import Optional
+from typing import Optional, Tuple, cast
 
 import pytest
+import typer
 from pydantic import BaseModel
 from pydantic import ValidationError
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 
+import anaconda_cli_base.cli
 from anaconda_cli_base.config import AnacondaBaseSettings
 from anaconda_cli_base.config import AnacondaConfigTomlSyntaxError
 from anaconda_cli_base.config import AnacondaConfigValidationError
+from anaconda_cli_base.plugins import load_registered_subcommands
 
+from .conftest import CLIInvoker
+
+ENTRY_POINT_TUPLE = Tuple[str, str, typer.Typer]
 
 class Nested(BaseModel):
     field: str = "default"
@@ -242,4 +248,63 @@ def test_settings_validation_error(
     assert "/config.toml in [plugin.derived] for foo = 1" in message
     assert "/config.toml in [plugin.derived] for nested.field = [0, 1, 2]" in message
     assert "Error in environment variable ANACONDA_DERIVED_OPTIONAL=not-an-integer" in message
-    assert "Error in DerivedSettings(not_required=3)" in message
+    assert "Error in init kwarg DerivedSettings(not_required=3)" in message
+
+
+@pytest.fixture
+def config_error_plugin(tmp_path: Path, monkeypatch: MonkeyPatch) -> ENTRY_POINT_TUPLE:
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_file))
+
+    plugin = typer.Typer(name="error", add_completion=False, no_args_is_help=True)
+
+    @plugin.command("syntax-error")
+    def syntax_error() -> None:
+        config_file.write_text(
+            dedent("""\
+            [plugin.derived]
+            foo = ["a"
+            [plugin.derived.nested]
+            field = "toml"
+        """)
+        )
+        _ = DerivedSettings()
+
+    @plugin.command("validation-error")
+    def validation_error() -> None:
+        monkeypatch.setenv("ANACONDA_DERIVED_OPTIONAL", "not-an-integer")
+
+        config_file.write_text(
+            dedent("""\
+            [plugin.derived]
+            foo = 1
+            [plugin.derived.nested]
+            field = [0, 1, 2]
+        """)
+        )
+        _ = DerivedSettings(not_required=3)
+
+    return ("config-error", "config-error-plugin:app", plugin)
+
+
+def test_error_handled(
+    invoke_cli: CLIInvoker,
+    config_error_plugin: ENTRY_POINT_TUPLE,
+    mocker: MockerFixture,
+) -> None:
+    plugins = [config_error_plugin]
+    mocker.patch(
+        "anaconda_cli_base.plugins._load_entry_points_for_group", return_value=plugins
+    )
+    load_registered_subcommands(cast(typer.Typer, anaconda_cli_base.cli.app))
+
+    result = invoke_cli(["config-error", "syntax-error"])
+    assert result.exit_code == 1
+    assert "/config.toml: Unclosed array (at line 3, column 1)" in result.stdout
+
+    result = invoke_cli(["config-error", "validation-error"])
+    assert result.exit_code == 1
+    assert "/config.toml in [plugin.derived] for foo = 1" in result.stdout
+    assert "/config.toml in [plugin.derived] for nested.field = [0, 1, 2]" in result.stdout
+    assert "Error in environment variable ANACONDA_DERIVED_OPTIONAL=not-an-integer" in result.stdout
+    assert "Error in init kwarg DerivedSettings(not_required=3)" in result.stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,6 @@ from typing import Optional, Tuple, cast
 import pytest
 import typer
 from pydantic import BaseModel
-from pydantic import ValidationError
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 
@@ -133,27 +132,6 @@ def test_settings_priority(
     config = DerivedSettings(foo="init", nested=Nested(field="init"))
     assert config.foo == "init"
     assert config.nested.field == "init"
-
-
-def test_settings_validation_failed(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path: Path
-) -> None:
-    config_file = tmp_path / "config.toml"
-    monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_file))
-
-    dotenv = tmp_path / ".env"
-    mocker.patch.dict(DerivedSettings.model_config, {"env_file": dotenv})
-
-    config_file.write_text(
-        dedent("""\
-        [plugin.derived]
-        foo = 0
-        [plugin.derived.nested]
-        field = "toml"
-    """)
-    )
-    with pytest.raises(ValidationError):
-        _ = DerivedSettings()
 
 
 def test_subclass(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -260,7 +260,7 @@ def config_error_plugin(tmp_path: Path, monkeypatch: MonkeyPatch) -> ENTRY_POINT
             field = [0, 1, 2]
         """)
         )
-        _ = DerivedSettings(not_required=3)
+        _ = DerivedSettings(not_required=3)  # type: ignore
 
     return ("config-error", "config-error-plugin:app", plugin)
 


### PR DESCRIPTION
The `AnacondaBaseSettings` (and its derived classes) is amended to throw two new exceptions

* `AnacondaConfigTomlSyntaxError`: When a syntax error is encountered in `~/.anaconda/config.toml`
* `AnacondaConfigValidationError`: catch validation errors from Pydantic (-settings) and format them more appropriately 
    * validation errors thrown from a subclass of `AnacondaBaseSettings` will determine where the offending configuration value came from: init kwargs to the class, env variables (or .env file), the config.toml file

See the screen shots for demos of the two new exceptions

## syntax error
<img width="856" alt="Screenshot 2025-05-15 at 23 30 59" src="https://github.com/user-attachments/assets/4ca388f9-cff2-49ea-abf9-eda0225a6a43" />

## validation error

<img width="625" alt="Screenshot 2025-05-15 at 23 31 16" src="https://github.com/user-attachments/assets/968da0c6-7d06-4468-9e94-c5f895cad2a5" />
