### PR TITLE
[chore] relax click constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["hatchling", "hatch-vcs>=0.3", "setuptools-scm>=7.1"]
 [project]
 dependencies = [
   "rich",
-  "click <8.2",
+  "click",
   "readchar",
   "typer",
   "packaging >=23.0",


### PR DESCRIPTION
Typer version 0.16.0 has been [released](https://github.com/fastapi/typer/releases/tag/0.16.0). This includes the fix for click >= 8.2. As such the constraint is relaxed. 