### PR TITLE
[chore] allow plugins to define top-level config keys

### DIFF
--- a/src/anaconda_cli_base/config.py
+++ b/src/anaconda_cli_base/config.py
@@ -53,7 +53,7 @@ class AnacondaBaseSettings(BaseSettings):
         if plugin_name is None:
             pyproject_toml_table_header = ()
             env_prefix = base_env_prefix
-        if isinstance(plugin_name, tuple):
+        elif isinstance(plugin_name, tuple):
             if not all(isinstance(entry, str) for entry in plugin_name):
                 raise ValueError(f"plugin_name={plugin_name} error: All values must be strings.")
             pyproject_toml_table_header = ("plugin", *plugin_name)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from textwrap import dedent
-from typing import Optional, Tuple, cast
+from typing import Optional, Tuple, cast, Dict
 
 import pytest
 import typer
@@ -286,3 +286,16 @@ def test_error_handled(
     assert "/config.toml in [plugin.derived] for nested.field = [0, 1, 2]" in result.stdout
     assert "Error in environment variable ANACONDA_DERIVED_OPTIONAL=not-an-integer" in result.stdout
     assert "Error in init kwarg DerivedSettings(not_required=3)" in result.stdout
+
+
+def test_root_level_table(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_file))
+
+    class RootLevelTable(AnacondaBaseSettings, plugin_name=None):
+        table: Optional[Dict[str, str]] = None
+
+    config_file.write_text("[table]\nkey = 'value'")
+
+    config = RootLevelTable()
+    assert config.table == {"key": "value"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -293,9 +293,15 @@ def test_root_level_table(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_file))
 
     class RootLevelTable(AnacondaBaseSettings, plugin_name=None):
+        foo: str = "bar"
         table: Optional[Dict[str, str]] = None
 
-    config_file.write_text("[table]\nkey = 'value'")
+    config_file.write_text(dedent("""\
+        foo = "baz"
+        [table]
+        key = "value"
+    """))
 
     config = RootLevelTable()
     assert config.table == {"key": "value"}
+    assert config.foo == "baz"


### PR DESCRIPTION
This fixes a bug where `plugin_name=None` was not supported

```python
from anaconda_cli_base.config import AnacondaBaseSettings

class RootLevelConfig(AnacondaBaseSettings, plugin_name=None):
    foo: str = "bar"
    table: Optional[Dict[str, str]] = None
```

this means that `~/.anaconda/config.toml` can look like

```toml
foo = "baz"

[table]
key = "value"

## other plugin tables below
```