### PR TITLE
fix: Ensure pre-commit gets run during CI

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -38,14 +38,22 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ runner.arch }}-${{ hashFiles('.pre-commit-config.yaml', '.tflint.hcl') }}
 
+      - name: Create conda environment
+        run: |
+          source $CONDA/bin/activate
+          conda env create -n pre-commit --file ./etc/pre-commit-environment.yml
+
       - name: Install pre-commit hooks
         # Ensure all hooks are installed so that the following pre-commit run step only measures
         # the time for the actual pre-commit run.
-        run: make install-hooks
+        run: |
+          source $CONDA/bin/activate && conda activate pre-commit
+          make install-hooks
 
       # Adapted from https://github.com/pre-commit/action/blob/efd3bcfec120bd343786e46318186153b7bc8c68/action.yml#L19
       - name: Run pre-commit
         run: |
+          source $CONDA/bin/activate && conda activate pre-commit
           # /usr/bin/time -v measure the time and memory usage
           /usr/bin/time -v make pre-commit
 

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,24 @@ conda_env_dir ?= ./env
 CONDA_EXE ?= conda
 CONDA_RUN := $(CONDA_EXE) run --prefix $(conda_env_dir) --no-capture-output
 
-.PHONY: help setup type-check test tox clean clean-all
+.PHONY: help setup install-hooks pre-commit type-check test tox clean clean-all
 
 help:  ## Display help on all Makefile targets
 	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
 
 setup:  ## Setup local dev conda environment
 	$(CONDA_EXE) env $(shell [ -d $(conda_env_dir) ] && echo update || echo create) -p $(conda_env_dir) --file environment-dev.yml
+
+install-hooks:  ## Install pre-commit hooks
+	pre-commit install-hooks
+
+pre-commit:  ## Run pre-commit against all files
+	@if ! which pre-commit >/dev/null; then \
+		echo "Install pre-commit via brew/conda"; \
+		echo "  e.g. 'brew install pre-commit'"; \
+		exit 1; \
+	fi
+	pre-commit run --verbose --show-diff-on-failure --color=always --all-files
 
 type-check:  ## Run the type checker locally
 	$(CONDA_RUN) mypy

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ conda_env_dir ?= ./env
 CONDA_EXE ?= conda
 CONDA_RUN := $(CONDA_EXE) run --prefix $(conda_env_dir) --no-capture-output
 
+.PHONY: help setup type-check test tox clean clean-all
+
 help:  ## Display help on all Makefile targets
 	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
 
@@ -27,5 +29,3 @@ clean:  ## Clean up cache and temporary files
 clean-all: clean  ## Clean up, including build files and conda environment
 	find . -name \*.egg-info -delete
 	rm -rf $(conda_env_dir)
-
-.PHONY: $(MAKECMDGOALS)

--- a/etc/pre-commit-environment.yml
+++ b/etc/pre-commit-environment.yml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - pre-commit

--- a/etc/pre-commit-environment.yml
+++ b/etc/pre-commit-environment.yml
@@ -1,4 +1,5 @@
 channels:
   - conda-forge
 dependencies:
-  - pre-commit
+  # renovate: datasource=conda depName=conda-forge/pre-commit
+  - pre-commit=4.3.0

--- a/src/anaconda_cli_base/config.py
+++ b/src/anaconda_cli_base/config.py
@@ -91,7 +91,7 @@ class AnacondaBaseSettings(BaseSettings):
                 env_prefix = self.model_config.get("env_prefix", "")
                 delimiter = self.model_config.get("env_nested_delimiter", "") or ""
                 env_var = env_prefix + delimiter.join(
-                    str(l).upper() for l in error["loc"]
+                    str(loc).upper() for loc in error["loc"]
                 )
 
                 kwarg = error["loc"][0]
@@ -104,7 +104,7 @@ class AnacondaBaseSettings(BaseSettings):
                     table_header = ".".join(
                         self.model_config.get("pyproject_toml_table_header", [])
                     )
-                    key = ".".join(str(l) for l in error["loc"])
+                    key = ".".join(str(loc) for loc in error["loc"])
                     msg = f"- Error in {anaconda_config_path()} in [{table_header}] for {key} = {input_value}\n    {msg}"
 
                 errors.append(msg)

--- a/src/anaconda_cli_base/config.py
+++ b/src/anaconda_cli_base/config.py
@@ -42,8 +42,8 @@ class AnacondaConfigTomlSettingsSource(PyprojectTomlConfigSettingsSource):
             arg = f"{anaconda_config_path()}: {e.args[0]}"
             raise AnacondaConfigTomlSyntaxError(arg)
 
-class AnacondaBaseSettings(BaseSettings):
 
+class AnacondaBaseSettings(BaseSettings):
     def __init_subclass__(
         cls, plugin_name: Optional[Union[str, tuple]] = None, **kwargs: Any
     ) -> None:
@@ -55,14 +55,18 @@ class AnacondaBaseSettings(BaseSettings):
             env_prefix = base_env_prefix
         elif isinstance(plugin_name, tuple):
             if not all(isinstance(entry, str) for entry in plugin_name):
-                raise ValueError(f"plugin_name={plugin_name} error: All values must be strings.")
+                raise ValueError(
+                    f"plugin_name={plugin_name} error: All values must be strings."
+                )
             pyproject_toml_table_header = ("plugin", *plugin_name)
             env_prefix = base_env_prefix + "_".join(plugin_name).upper() + "_"
         elif isinstance(plugin_name, str):
             pyproject_toml_table_header = ("plugin", plugin_name)
             env_prefix = base_env_prefix + f"{plugin_name.upper()}_"
         else:
-            raise ValueError(f"plugin_name={plugin_name} is not supported. It must be either a str or tuple.")
+            raise ValueError(
+                f"plugin_name={plugin_name} is not supported. It must be either a str or tuple."
+            )
 
         cls.model_config = SettingsConfigDict(
             env_file=".env",
@@ -86,7 +90,9 @@ class AnacondaBaseSettings(BaseSettings):
 
                 env_prefix = self.model_config.get("env_prefix", "")
                 delimiter = self.model_config.get("env_nested_delimiter", "") or ""
-                env_var = env_prefix + delimiter.join(str(l).upper() for l in error["loc"])
+                env_var = env_prefix + delimiter.join(
+                    str(l).upper() for l in error["loc"]
+                )
 
                 kwarg = error["loc"][0]
                 if kwarg in kwargs:
@@ -95,7 +101,9 @@ class AnacondaBaseSettings(BaseSettings):
                 elif env_var in os.environ:
                     msg = f"- Error in environment variable {env_var}={input_value}\n    {msg}"
                 else:
-                    table_header = ".".join(self.model_config.get("pyproject_toml_table_header", []))
+                    table_header = ".".join(
+                        self.model_config.get("pyproject_toml_table_header", [])
+                    )
                     key = ".".join(str(l) for l in error["loc"])
                     msg = f"- Error in {anaconda_config_path()} in [{table_header}] for {key} = {input_value}\n    {msg}"
 

--- a/src/anaconda_cli_base/exceptions.py
+++ b/src/anaconda_cli_base/exceptions.py
@@ -11,6 +11,7 @@ else:
 
 ErrorHandlingCallback = Callable[[Exception], int]
 
+
 class AnacondaConfigTomlSyntaxError(tomllib.TOMLDecodeError): ...
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ from .conftest import CLIInvoker
 
 ENTRY_POINT_TUPLE = Tuple[str, str, typer.Typer]
 
+
 class Nested(BaseModel):
     field: str = "default"
 
@@ -48,21 +49,17 @@ def test_settings_plugin_name_tuple() -> None:
     env_prefix = TupleName.model_config.get("env_prefix", "")
     assert env_prefix == "ANACONDA_NESTED_SETTINGS_"
 
-    table_header = TupleName.model_config.get(
-        "pyproject_toml_table_header", tuple()
-    )
-    assert table_header == (
-        "plugin",
-        "nested",
-        "settings"
-    )
+    table_header = TupleName.model_config.get("pyproject_toml_table_header", tuple())
+    assert table_header == ("plugin", "nested", "settings")
 
 
 def test_settings_plugin_name_error() -> None:
     with pytest.raises(ValueError):
+
         class FailList(DerivedSettings, plugin_name=["nested", "settings"]): ...
 
     with pytest.raises(ValueError):
+
         class FailType(DerivedSettings, plugin_name=["nested", 0]): ...
 
 
@@ -139,6 +136,7 @@ def test_subclass(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_file))
 
     class Subclass(DerivedSettings, plugin_name="subclass"): ...
+
     assert Subclass.model_config.get("env_prefix", "") == "ANACONDA_SUBCLASS_"
 
     config_file.write_text(
@@ -182,9 +180,7 @@ def test_nested_plugins(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     assert config.value == "env"
 
 
-def test_settings_toml_error(
-    monkeypatch: MonkeyPatch, tmp_path: Path
-) -> None:
+def test_settings_toml_error(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     config_file = tmp_path / "config.toml"
     monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_file))
 
@@ -203,9 +199,7 @@ def test_settings_toml_error(
     assert "/config.toml: Unclosed array (at line 3, column 1)" in excinfo.value.args[0]
 
 
-def test_settings_validation_error(
-    monkeypatch: MonkeyPatch, tmp_path: Path
-) -> None:
+def test_settings_validation_error(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     config_file = tmp_path / "config.toml"
     monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_file))
     monkeypatch.setenv("ANACONDA_DERIVED_OPTIONAL", "not-an-integer")
@@ -225,7 +219,10 @@ def test_settings_validation_error(
     message = excinfo.value.args[0]
     assert "/config.toml in [plugin.derived] for foo = 1" in message
     assert "/config.toml in [plugin.derived] for nested.field = [0, 1, 2]" in message
-    assert "Error in environment variable ANACONDA_DERIVED_OPTIONAL=not-an-integer" in message
+    assert (
+        "Error in environment variable ANACONDA_DERIVED_OPTIONAL=not-an-integer"
+        in message
+    )
     assert "Error in init kwarg DerivedSettings(not_required=3)" in message
 
 
@@ -283,8 +280,13 @@ def test_error_handled(
     result = invoke_cli(["config-error", "validation-error"])
     assert result.exit_code == 1
     assert "/config.toml in [plugin.derived] for foo = 1" in result.stdout
-    assert "/config.toml in [plugin.derived] for nested.field = [0, 1, 2]" in result.stdout
-    assert "Error in environment variable ANACONDA_DERIVED_OPTIONAL=not-an-integer" in result.stdout
+    assert (
+        "/config.toml in [plugin.derived] for nested.field = [0, 1, 2]" in result.stdout
+    )
+    assert (
+        "Error in environment variable ANACONDA_DERIVED_OPTIONAL=not-an-integer"
+        in result.stdout
+    )
     assert "Error in init kwarg DerivedSettings(not_required=3)" in result.stdout
 
 
@@ -296,11 +298,13 @@ def test_root_level_table(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
         foo: str = "bar"
         table: Optional[Dict[str, str]] = None
 
-    config_file.write_text(dedent("""\
+    config_file.write_text(
+        dedent("""\
         foo = "baz"
         [table]
         key = "value"
-    """))
+    """)
+    )
 
     config = RootLevelTable()
     assert config.table == {"key": "value"}


### PR DESCRIPTION
## Summary

We were missing the `Makefile` targets to run `pre-commit` in CI. This was caused by the use of `.PHONY: $(MAKECMDGOALS)`, which makes all targets appear to be valid.

We make two changes to fix the bug and prevent bugs like it in the future:

1. Use an explicit `.PHONY` list (this should cause CI to fail)
2. Add the missing `Makefile` targets