### PR TITLE
Cache TOML file reads

### DIFF
--- a/src/anaconda_cli_base/config.py
+++ b/src/anaconda_cli_base/config.py
@@ -4,6 +4,7 @@ import sys
 from functools import cached_property
 from pathlib import Path
 from typing import Any
+from typing import ClassVar
 from typing import Dict
 from typing import Optional
 from typing import Tuple
@@ -44,9 +45,15 @@ def anaconda_config_path() -> Path:
 
 
 class AnacondaConfigTomlSettingsSource(PyprojectTomlConfigSettingsSource):
+    _cache: ClassVar[Dict[Path, Dict[str, Any]]] = {}
+
     def _read_file(self, file_path: Path) -> Dict[str, Any]:
         try:
-            return super()._read_file(file_path)
+            result = self._cache.get(file_path)
+            if result is None:
+                result = super()._read_file(file_path)
+                self._cache[file_path] = result
+            return result
         except tomllib.TOMLDecodeError as e:
             arg = f"{anaconda_config_path()}: {e.args[0]}"
             raise AnacondaConfigTomlSyntaxError(arg)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ from pytest_mock import MockerFixture
 
 import anaconda_cli_base.cli
 from anaconda_cli_base.config import AnacondaBaseSettings
+from anaconda_cli_base.config import AnacondaConfigTomlSettingsSource
 from anaconda_cli_base.exceptions import AnacondaConfigTomlSyntaxError
 from anaconda_cli_base.exceptions import AnacondaConfigValidationError
 from anaconda_cli_base.plugins import load_registered_subcommands
@@ -81,6 +82,7 @@ def test_settings_priority(
     assert config.nested.field == "default"
     assert config.docker_test == "default"
 
+    AnacondaConfigTomlSettingsSource._cache.clear()
     config_file.write_text(
         dedent("""\
         [plugin.derived]
@@ -95,6 +97,7 @@ def test_settings_priority(
     assert config.nested.field == "toml"
     assert config.docker_test == "toml"
 
+    AnacondaConfigTomlSettingsSource._cache.clear()
     config_file.write_text(
         dedent("""\
         [plugin.derived]
@@ -108,6 +111,7 @@ def test_settings_priority(
     assert config.nested.field == "toml_inline"
     assert config.docker_test == "toml"
 
+    AnacondaConfigTomlSettingsSource._cache.clear()
     config_file.write_text(
         dedent("""\
         [plugin.derived]


### PR DESCRIPTION
Cache the reading of the TOML files. Because of the way we have structured `AnacondaAuthSitesConfig` in particular, we're doing a lot of repeated reads of these files. We could, in theory, clean up the logic to eliminate the reads, and maybe we should, but this is 90% of the benefit IMO.