### PR TITLE
fix: Format error message for unsupported value of `--at`

### DIFF
--- a/src/anaconda_cli_base/plugins.py
+++ b/src/anaconda_cli_base/plugins.py
@@ -92,7 +92,9 @@ def _select_auth_handler_and_args(
             (at, _) = default_auth_handler
 
     if at not in auth_handlers:
-        handlers = "".join([f"\n* {display_name}" for _, display_name in auth_handlers_dropdown])
+        handlers = "".join(
+            [f"\n* {display_name}" for _, display_name in auth_handlers_dropdown]
+        )
         msg = f"{at} is not an allowed value for --at. Use one of {handlers}"
         console.print(msg)
         raise typer.Abort()


### PR DESCRIPTION
Here's what currently happens

<img width="1011" height="89" alt="Screenshot 2025-12-01 at 10 27 30" src="https://github.com/user-attachments/assets/678904bb-9df1-4694-b6f8-42dc5e179d39" />

this PR improves the formatting to make it look more like the interactive selector

<img width="492" height="120" alt="Screenshot 2025-12-01 at 10 28 29" src="https://github.com/user-attachments/assets/4a7a0003-47fb-4515-bd66-b83627ccf7f3" />
