### PR TITLE
[chore] safely get value from full dump

### DIFF
--- a/src/anaconda_cli_base/config.py
+++ b/src/anaconda_cli_base/config.py
@@ -284,7 +284,7 @@ class AnacondaBaseSettings(BaseSettings):
                     # If a key was already present in toml
                     # ensure that it remains set even if the
                     # new value is the default for the class
-                    value = current_full[k]
+                    value = current_full.get(k, None)
                     if (value is not None) and preserve_existing_keys:
                         current_original[k] = value
                     else:


### PR DESCRIPTION
One case where `model_dump()` does not list all potential keys that could be found in the config.toml is when a RootModel is used, for example in nested tables where any arbitrary number of tables of a certain type may be present.

```toml
[plugin.mapper.map.foo]
key = "foo"

[plugin.mapper.map.bar]
key = "bar"
```

Here the `map` table name is a RootModel to maintain a dictionary of Items where the key is inferred from the table name in the config.toml.

```python
class Item(BaseModel):
    key: Optional[str] = None

Mapping = RootModel[Dict[str, Item]]

class MappingPlugin(AnacondaBaseSettings, plugin_name="mapper"):
    map: Mapping = Mapping({})
``` 

In this scenario when an entry is dropped from `map` 

```python
plugin = MappingPlugin()
del plugin.map.root["foo"]
```

The dump of `plugin` can never be assumed to have exactly the same keys as when the configuration was read from disk. This would be equivalent to calling `delattr()` on a subclass of BaseModel after initialization.