### PR TITLE
[chore] use flags= with re.sub

### DIFF
--- a/src/anaconda_cli_base/config.py
+++ b/src/anaconda_cli_base/config.py
@@ -357,7 +357,7 @@ class AnacondaBaseSettings(BaseSettings):
         )
         try:
             config_dump = tomlkit.dumps(to_update)
-            config_dump = re.sub(r"\n+$", "\n", config_dump, re.DOTALL)
+            config_dump = re.sub(r"\n+$", "\n", config_dump, flags=re.DOTALL)
             with os.fdopen(tmp_fd, "wt") as f:
                 f.write(config_dump)
             # Atomic rename - if this fails, original file is untouched


### PR DESCRIPTION
this is causing an error since anaconda-auth promotes warnings to errors in its CI/CD. It was was also bug as the 3rd positional arg to `re.sub` is `count=`, not flags. This wasn't caught because `re.DOTALL` is enum 16.