### PR TITLE
fix missing args on error

### DIFF
--- a/src/anaconda_cli_base/cli.py
+++ b/src/anaconda_cli_base/cli.py
@@ -64,6 +64,10 @@ class ErrorHandledGroup(TyperGroup):
                     **extra,
                 )
             else:
+                # this happens in self.main
+                # so the above is still correct
+                if not args:
+                    args = sys.argv[1:]
                 cmd = " ".join(args or [])
                 console.print(
                     f"\nTo see a more detailed error message run the command again as"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -740,6 +740,40 @@ def test_error_handled_recommend_verbose(
     assert lines[-1].strip() == "anaconda --verbose error custom-catch arg"
 
 
+def test_error_handled_recommend_verbose_args_none(
+    error_plugin: ENTRY_POINT_TUPLE,
+    mocker: MockerFixture,
+    monkeypatch: MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test the verbose hint includes args when main() is called with args=None.
+
+    The real CLI entry point calls ErrorHandledGroup.main(args=None), which
+    means Click reads sys.argv internally.  The error handler must still
+    reconstruct the original command for the 'anaconda --verbose ...' hint.
+    """
+    monkeypatch.delenv("ANACONDA_CLI_FORCE_NEW", raising=False)
+    monkeypatch.delenv("ANACONDA_CLIENT_FORCE_STANDALONE", raising=False)
+
+    plugins = [error_plugin]
+    mocker.patch(
+        "anaconda_cli_base.plugins._load_entry_points_for_group", return_value=plugins
+    )
+    app = cast(typer.Typer, anaconda_cli_base.cli.app)
+    load_registered_subcommands(app)
+
+    click_app = typer.main.get_command(app)
+
+    # Simulate real CLI: args=None, sys.argv has the command
+    monkeypatch.setattr(sys, "argv", ["anaconda", "error", "auto-catch"])
+    with pytest.raises(SystemExit) as exc_info:
+        click_app.main(args=None, standalone_mode=True)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "anaconda --verbose error auto-catch" in captured.out
+
+
 @pytest.mark.parametrize(
     "options, top_options, expected_handler, expected_args",
     [


### PR DESCRIPTION
Again the error message was not working, the tests pass because the invoke-cli forces a certain behavior where `args=` is passed, but in reality click re-reads from `sys.argv[1:]` along the way.

The bug

<img width="507" height="89" alt="Screenshot 2026-03-27 at 11 39 38" src="https://github.com/user-attachments/assets/b404ca71-8cab-4b49-a267-4033d1a17b05" />

now fixed

<img width="505" height="93" alt="Screenshot 2026-03-27 at 11 40 23" src="https://github.com/user-attachments/assets/194568eb-5307-4e22-b820-a408f86fde2d" />
