### PR TITLE
add support for rc tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,28 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
 
+  determine-release-type:
+    name: Determine release type
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.check.outputs.label }}
+      is_stable: ${{ steps.check.outputs.is_stable }}
+    steps:
+    - name: Detect release type
+      id: check
+      run: |
+        if [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "label=" >> $GITHUB_OUTPUT
+          echo "is_stable=true" >> $GITHUB_OUTPUT
+        else
+          echo "label=--label dev" >> $GITHUB_OUTPUT
+          echo "is_stable=false" >> $GITHUB_OUTPUT
+        fi
+
   publish-conda-pkg-to-anaconda-dot-org:
     name: Publish conda package to Anaconda.org
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, determine-release-type]
     steps:
     - name: Retrieve the source code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -34,20 +52,18 @@ jobs:
         TOKEN: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
       run: |
         source $CONDA/bin/activate && conda activate build
-        # If it's not a tagged release, publish to dev label
-        [[ "$GITHUB_REF" =~ ^refs/tags/v ]] || export LABEL="--label dev"
         anaconda --verbose \
           --token $TOKEN \
           upload \
           --user anaconda-cloud \
-          $LABEL \
+          ${{ needs.determine-release-type.outputs.label }} \
           --force \
           ./conda-bld/noarch/anaconda-*
 
   publish-wheel-to-anaconda-dot-org:
     name: Publish wheel to Anaconda.org
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, determine-release-type]
     steps:
     - name: Retrieve the source code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -65,25 +81,21 @@ jobs:
     - name: Upload to anaconda.org
       env:
         TOKEN: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
-        GITHUB_REF: ${{ github.ref }}
       run: |
         source $CONDA/bin/activate && conda activate build
-        # If it's not a tagged release, publish to dev label
-        [[ "$GITHUB_REF" =~ ^refs/tags/v ]] || export LABEL="--label dev"
         anaconda --verbose \
           --token $TOKEN \
           upload \
           --user anaconda-cloud \
-          $LABEL \
+          ${{ needs.determine-release-type.outputs.label }} \
           --force \
           ./dist/*.whl
 
   publish-to-pypi:
     name: Publish to PyPI
-    # Only publish to PyPI if a tagged release
-    if: startsWith(github.event.ref, 'refs/tags/v')
+    needs: [test, determine-release-type]
+    if: needs.determine-release-type.outputs.is_stable == 'true'
     runs-on: ubuntu-latest
-    needs: [test]
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ deps =
     pytest-mock
     typer !=0.12.2
 conda_deps =
+    pip
     anaconda-auth >=0.11
 conda_channels =
     anaconda-cloud


### PR DESCRIPTION
Push a tag like `1.0.0-rc1` and it will be sent to `anaconda-cloud/label/dev` without publishing to pypi. Then we can internally test this version by manually using the version number. This matches patterns found elsewhere in anaconda.

Under the hood it is treating any version tag that doesn't match semver as non-prod and skipping pypi publishing.