### PR TITLE
Automatic CLI telemetry and optional module for plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           run: |
             source $CONDA/bin/activate && conda activate build
             mkdir -p ./conda-bld
-            VERSION=`hatch version` conda build -c conda-forge -c defaults --override-channels conda.recipe --output-folder ./conda-bld
+            VERSION=`hatch version` conda-build -c conda-forge -c defaults --override-channels conda.recipe --output-folder ./conda-bld
         - name: Upload the build artifact
           uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
           with:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ as environment variables with the `ANACONDA_TELEMETRY_` prefix.
 | `share_session_identity` | `ANACONDA_TELEMETRY_SHARE_SESSION_IDENTITY` | `true` | Include anonymous session tokens for usage correlation |
 | `proxy_url` | `ANACONDA_TELEMETRY_PROXY_URL` | None | HTTP proxy for telemetry export (for corporate networks) |
 | `flush_timeout_ms` | `ANACONDA_TELEMETRY_FLUSH_TIMEOUT_MS` | `500` | Max milliseconds to wait for telemetry flush on CLI exit |
+| `export_interval_ms` | `ANACONDA_TELEMETRY_EXPORT_INTERVAL_MS` | `60000` | Millisecond frequency over which data is exported for long-running tasks |
 
 When `share_session_identity` is `true`, hashed machine and session tokens are included with telemetry
 data. These allow Anaconda to correlate usage patterns across CLI sessions without identifying you personally.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,42 @@
 
 A base CLI entrypoint supporting Anaconda CLI plugins using [Typer](https://github.com/fastapi/typer).
 
+## Telemetry
+
+The CLI automatically reports command execution metrics for all registered plugins via
+[anaconda-opentelemetry](https://github.com/anaconda/anaconda-otel-python). Every command invocation
+records the command name, execution duration, and success/failure status. No plugin changes are required.
+
+### Disabling telemetry
+
+Telemetry is enabled by default. To disable:
+
+```bash
+export ANACONDA_TELEMETRY_ENABLED=false
+```
+
+Or in `~/.anaconda/config.toml`:
+
+```toml
+[telemetry]
+enabled = false
+```
+
+### Configuration
+
+Telemetry settings live in the `[telemetry]` section of `~/.anaconda/config.toml` or
+as environment variables with the `ANACONDA_TELEMETRY_` prefix.
+
+| Setting | Env Variable | Default | Description |
+|---------|-------------|---------|-------------|
+| `enabled` | `ANACONDA_TELEMETRY_ENABLED` | `true` | Enable or disable all CLI telemetry |
+| `share_session_identity` | `ANACONDA_TELEMETRY_SHARE_SESSION_IDENTITY` | `true` | Include anonymous session tokens for usage correlation |
+| `proxy_url` | `ANACONDA_TELEMETRY_PROXY_URL` | None | HTTP proxy for telemetry export (for corporate networks) |
+
+When `share_session_identity` is `true`, hashed machine and session tokens are included with telemetry
+data. These allow Anaconda to correlate usage patterns across CLI sessions without identifying you personally.
+Set to `false` to send only standalone metrics with no session linking.
+
 ## Registering plugins
 
 To develop a subcommand in a third-party package, first create a `typer.Typer()` app with one or more commands.
@@ -323,6 +359,27 @@ If instead we wish to remove keys when set to their default value pass the `pres
 ```
 
 See the [tests](https://github.com/anaconda/anaconda-cli-base/blob/main/tests/test_config.py) for more examples of reading and writing plugin configuration.
+
+### Plugin telemetry
+
+Plugins get baseline command metrics for free. To add custom instrumentation:
+
+```python
+from anaconda_cli_base.telemetry import traced, count, histogram, log_event
+
+@app.command()
+def download(model: str):
+    with traced("models_download", plugin_name="ai", attributes={"model": model}) as span:
+        result = do_download(model)
+        span.add_event("download_complete", {"size_bytes": result.size})
+    count("models_downloaded", plugin_name="ai")
+    histogram("download_size_bytes", plugin_name="ai", value=result.size)
+```
+
+The `plugin_name` should match your registered subcommand name (e.g., `"ai"` for `anaconda ai`).
+This ensures custom telemetry correlates with the automatic command metrics in dashboards.
+
+All functions are no-ops when telemetry is disabled — they will never raise or affect CLI behavior.
 
 ## Setup for development
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ as environment variables with the `ANACONDA_TELEMETRY_` prefix.
 | Setting | Env Variable | Default | Description |
 |---------|-------------|---------|-------------|
 | `enabled` | `ANACONDA_TELEMETRY_ENABLED` | `true` | Enable or disable all CLI telemetry |
-| `endpoint` | `ANACONDA_TELEMETRY_ENDPOINT` | `null` | Set a custom OTEL endpoint ur. If `null` uses anaconda.com endpoint |
+| `endpoint` | `ANACONDA_TELEMETRY_ENDPOINT` | `None` | Set a custom OTEL endpoint ur. If `None` uses anaconda.com endpoint |
 | `share_session_identity` | `ANACONDA_TELEMETRY_SHARE_SESSION_IDENTITY` | `true` | Include anonymous session tokens for usage correlation |
 | `proxy_url` | `ANACONDA_TELEMETRY_PROXY_URL` | None | HTTP proxy for telemetry export (for corporate networks) |
 | `flush_timeout_ms` | `ANACONDA_TELEMETRY_FLUSH_TIMEOUT_MS` | `500` | Max milliseconds to wait for telemetry flush on CLI exit |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ as environment variables with the `ANACONDA_TELEMETRY_` prefix.
 | Setting | Env Variable | Default | Description |
 |---------|-------------|---------|-------------|
 | `enabled` | `ANACONDA_TELEMETRY_ENABLED` | `true` | Enable or disable all CLI telemetry |
+| `endpoint` | `ANACONDA_TELEMETRY_ENDPOINT` | `null` | Set a custom OTEL endpoint ur. If `null` uses anaconda.com endpoint |
 | `share_session_identity` | `ANACONDA_TELEMETRY_SHARE_SESSION_IDENTITY` | `true` | Include anonymous session tokens for usage correlation |
 | `proxy_url` | `ANACONDA_TELEMETRY_PROXY_URL` | None | HTTP proxy for telemetry export (for corporate networks) |
 | `flush_timeout_ms` | `ANACONDA_TELEMETRY_FLUSH_TIMEOUT_MS` | `500` | Max milliseconds to wait for telemetry flush on CLI exit |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ as environment variables with the `ANACONDA_TELEMETRY_` prefix.
 | `enabled` | `ANACONDA_TELEMETRY_ENABLED` | `true` | Enable or disable all CLI telemetry |
 | `share_session_identity` | `ANACONDA_TELEMETRY_SHARE_SESSION_IDENTITY` | `true` | Include anonymous session tokens for usage correlation |
 | `proxy_url` | `ANACONDA_TELEMETRY_PROXY_URL` | None | HTTP proxy for telemetry export (for corporate networks) |
+| `flush_timeout_ms` | `ANACONDA_TELEMETRY_FLUSH_TIMEOUT_MS` | `500` | Max milliseconds to wait for telemetry flush on CLI exit |
 
 When `share_session_identity` is `true`, hashed machine and session tokens are included with telemetry
 data. These allow Anaconda to correlate usage patterns across CLI sessions without identifying you personally.
@@ -380,6 +381,36 @@ The `plugin_name` should match your registered subcommand name (e.g., `"ai"` for
 This ensures custom telemetry correlates with the automatic command metrics in dashboards.
 
 All functions are no-ops when telemetry is disabled — they will never raise or affect CLI behavior.
+
+### Logging handler
+
+For error and warning capture via Python's standard `logging` module, attach the OTel handler
+to your plugin's logger. By default log records at WARNING and above are exported to the telemetry backend
+while still flowing to any other handlers (stderr, file) you have configured.
+
+```python
+import logging
+from anaconda_cli_base.telemetry import get_otel_handler
+
+log = logging.getLogger("anaconda_ai")
+log.addHandler(get_otel_handler())
+
+# WARNING+ goes to OTel; all levels still go to other handlers
+log.warning("retry attempt", extra={"attempt": 3, "endpoint": url})
+log.error("download failed", extra={"model": model, "error.type": "TimeoutError"})
+```
+
+Pass a custom level to change the threshold:
+
+```python
+log.addHandler(get_otel_handler(level=logging.ERROR))  # Only errors
+```
+
+When telemetry is disabled or `anaconda-opentelemetry` is not installed, `get_otel_handler()`
+returns a `NullHandler` — safe to call unconditionally with zero overhead.
+
+Use `get_otel_handler()` for structured errors/warnings. Use `log_event()` for business events
+that shouldn't appear in developer console output (e.g., `"model_downloaded"`, `"session_started"`).
 
 ## Setup for development
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ def download(model: str):
         span.add_event("download_complete", {"size_bytes": result.size})
     count("models_downloaded", plugin_name="ai")
     histogram("download_size_bytes", plugin_name="ai", value=result.size)
+    log_event("user downloaded a model", event_name="model_downloaded", plugin_name="ai", attributes={"model": model})
 ```
 
 The `plugin_name` should match your registered subcommand name (e.g., `"ai"` for `anaconda ai`).

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
   imports:
     - anaconda_cli_base
   commands:
-    - anaconda --version
+    - anaconda versions
     - python -c "from anaconda_cli_base import __version__; assert __version__ == \"{{ version }}\""
 about:
   summary: {{ project['description'] }}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     {% for dep in project['dependencies'] %}
     - {{ dep.lower() }}
     {% endfor %}
+    - anaconda-opentelemetry
   run_constrained:
     # Ensure coordinated rollout of changes related to multi-site configuration
     - anaconda-auth >=0.12.0

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,6 +4,7 @@ channels:
 - conda-forge
 dependencies:
 - python=3.10
+- anaconda-opentelemetry
 - tox=3
 - tox-conda
 - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ anaconda = "anaconda_cli_base.cli:app"
 [project.optional-dependencies]
 dev = [
   "mypy",
+  "oteltest",
   "pytest",
   "pytest-cov",
   "pytest-mock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ target-version = "py38"
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py310,py311,py312,py313,py314,mypy
+envlist = py310,py311,py312,py313,py314,py310-otel,py310-integration,mypy
 isolated_build = True
 requires =
     tox-conda
@@ -117,7 +117,7 @@ requires =
 
 [gh-actions]
 python =
-    3.10: py310, mypy
+    3.10: py310, py310-otel, py310-integration, mypy
     3.11: py311, mypy
     3.12: py312, mypy
     3.13: py313, mypy
@@ -133,12 +133,32 @@ deps =
 conda_deps =
     pip
     anaconda-auth >=0.11
-    anaconda-opentelemetry >=1.1.0
 conda_channels =
     anaconda-cloud
     defaults
     conda-forge
 commands = pytest -m "not integration"
+
+[testenv:py310-otel]
+deps =
+    {[testenv]deps}
+conda_deps =
+    {[testenv]conda_deps}
+    anaconda-opentelemetry >=1.1.0
+conda_channels =
+    {[testenv]conda_channels}
+commands = pytest -m "not integration"
+
+[testenv:py310-integration]
+deps =
+    {[testenv]deps}
+    oteltest
+conda_deps =
+    {[testenv]conda_deps}
+    anaconda-opentelemetry >=1.1.0
+conda_channels =
+    {[testenv]conda_channels}
+commands = pytest -m integration
 
 [testenv:mypy]
 deps =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
   "pydantic-settings >=2.3",
   "pydantic >=2.12",
   "tomli",
-  "tomlkit"
+  "tomlkit",
+  "anaconda-opentelemetry >=1.1.0"
 ]
 description = "A base CLI entrypoint supporting Anaconda CLI plugins"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ module = "rich_click.*"
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
-module = "oteltel.*"
+module = "oteltest.*"
 
 [tool.pytest.ini_options]
 addopts = [
@@ -134,6 +134,7 @@ deps =
     pytest-cov
     pytest-mock
     typer !=0.12.2
+    oteltest
 conda_deps =
     pip
     anaconda-auth >=0.11
@@ -174,6 +175,7 @@ deps =
     types-requests
     typer
     rich
+    oteltest
 conda_deps =
     anaconda-auth >=0.11
     anaconda-opentelemetry >=1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ deps =
 conda_deps =
     anaconda-auth >=0.11
     anaconda-opentelemetry >=1.1.0
+    pip
 conda_channels =
     anaconda-cloud
     defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ commands = pytest -m "not integration"
 [testenv:py310-otel]
 deps =
     {[testenv]deps}
+    oteltest
 conda_deps =
     {[testenv]conda_deps}
     anaconda-opentelemetry >=1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ deps =
 conda_deps =
     pip
     anaconda-auth >=0.11
+    anaconda-opentelemetry >=1.1.0
 conda_channels =
     anaconda-cloud
     defaults
@@ -147,8 +148,11 @@ deps =
     rich
 conda_deps =
     anaconda-auth >0.10.0
+    anaconda-opentelemetry >1.1.0
 conda_channels =
     anaconda-cloud
+    defaults
+    conda-forge
 commands = mypy
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,10 @@ module = "binstar_client.*"
 ignore_missing_imports = true
 module = "rich_click.*"
 
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
+module = "oteltel.*"
+
 [tool.pytest.ini_options]
 addopts = [
   "--cov=anaconda_cli_base",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,7 @@ dependencies = [
   "pydantic-settings >=2.3",
   "pydantic >=2.12",
   "tomli",
-  "tomlkit",
-  "anaconda-opentelemetry >=1.1.0"
+  "tomlkit"
 ]
 description = "A base CLI entrypoint supporting Anaconda CLI plugins"
 dynamic = ["version"]
@@ -40,6 +39,9 @@ publish = [
   "build",
   "twine",
   "wheel"
+]
+telemetry = [
+  "anaconda-opentelemetry >=1.1.0"
 ]
 
 [project.scripts]
@@ -147,8 +149,8 @@ deps =
     typer
     rich
 conda_deps =
-    anaconda-auth >0.10.0
-    anaconda-opentelemetry >1.1.0
+    anaconda-auth >=0.11
+    anaconda-opentelemetry >=1.1.0
 conda_channels =
     anaconda-cloud
     defaults

--- a/src/anaconda_cli_base/cli.py
+++ b/src/anaconda_cli_base/cli.py
@@ -61,7 +61,9 @@ class ErrorHandledGroup(TyperGroup):
         except SystemExit as e:
             if not self._retrying:
                 _after_command(
-                    command_info, success=(e.code in (None, 0)), exit_code=e.code or 0
+                    command_info,
+                    success=(e.code in (None, 0)),
+                    exit_code=int(e.code or 0),
                 )
             raise
         except Exception as e:
@@ -88,7 +90,7 @@ class ErrorHandledGroup(TyperGroup):
                     _after_command(
                         command_info,
                         success=(retry_exit.code in (None, 0)),
-                        exit_code=retry_exit.code or 0,
+                        exit_code=int(retry_exit.code or 0),
                     )
                     raise
                 finally:

--- a/src/anaconda_cli_base/cli.py
+++ b/src/anaconda_cli_base/cli.py
@@ -44,7 +44,8 @@ class ErrorHandledGroup(TyperGroup):
     ) -> None:
         command_info = None
         if not self._retrying:
-            command_info = _before_command(args, prog_name)
+            resolved_args = args if args is not None else sys.argv[1:]
+            command_info = _before_command(resolved_args, prog_name)
 
         try:
             super().main(

--- a/src/anaconda_cli_base/cli.py
+++ b/src/anaconda_cli_base/cli.py
@@ -60,7 +60,9 @@ class ErrorHandledGroup(TyperGroup):
                 _after_command(command_info, success=True)
         except SystemExit as e:
             if not self._retrying:
-                _after_command(command_info, success=(e.code in (None, 0)))
+                _after_command(
+                    command_info, success=(e.code in (None, 0)), exit_code=e.code or 0
+                )
             raise
         except Exception as e:
             ctx = self._get_context(args, prog_name, windows_expand_args, **extra)
@@ -83,14 +85,20 @@ class ErrorHandledGroup(TyperGroup):
                         **extra,
                     )
                 except SystemExit as retry_exit:
-                    _after_command(command_info, success=(retry_exit.code in (None, 0)))
+                    _after_command(
+                        command_info,
+                        success=(retry_exit.code in (None, 0)),
+                        exit_code=retry_exit.code or 0,
+                    )
                     raise
                 finally:
                     self._retrying = False
                 _after_command(command_info, success=True)
             else:
                 if not self._retrying:
-                    _after_command(command_info, success=False, error=e)
+                    _after_command(
+                        command_info, success=False, error=e, exit_code=exit_code
+                    )
                 if not args:
                     args = sys.argv[1:]
                 cmd = " ".join(args or [])

--- a/src/anaconda_cli_base/cli.py
+++ b/src/anaconda_cli_base/cli.py
@@ -22,9 +22,13 @@ from anaconda_cli_base import __version__
 from anaconda_cli_base import console
 from anaconda_cli_base.plugins import load_registered_subcommands
 from anaconda_cli_base.exceptions import ERROR_HANDLERS
+from anaconda_cli_base.telemetry import _before_command, _after_command
 
 
 class ErrorHandledGroup(TyperGroup):
+    # Set True during recursive retry (exit_code == -1) to avoid double-counting telemetry
+    _retrying: bool = False
+
     def list_commands(self, _: click.core.Context) -> List[str]:
         """Return list of commands in the order they appear on the CLI."""
         return sorted(self.commands, reverse=False)
@@ -38,6 +42,10 @@ class ErrorHandledGroup(TyperGroup):
         windows_expand_args: bool = True,
         **extra: Any,
     ) -> None:
+        command_info = None
+        if not self._retrying:
+            command_info = _before_command(args, prog_name)
+
         try:
             super().main(
                 args,
@@ -47,25 +55,41 @@ class ErrorHandledGroup(TyperGroup):
                 windows_expand_args,
                 **extra,
             )
+            if not self._retrying:
+                _after_command(command_info, success=True)
+        except SystemExit as e:
+            if not self._retrying:
+                _after_command(command_info, success=(e.code in (None, 0)))
+            raise
         except Exception as e:
             ctx = self._get_context(args, prog_name, windows_expand_args, **extra)
             if ctx.params.get("verbose", False):
+                if not self._retrying:
+                    _after_command(command_info, success=False, error=e)
                 raise e
 
             callback = ERROR_HANDLERS[type(e)]
             exit_code = callback(e)
             if exit_code == -1:
-                self.main(
-                    args,
-                    prog_name,
-                    complete_var,
-                    standalone_mode,
-                    windows_expand_args,
-                    **extra,
-                )
+                self._retrying = True
+                try:
+                    self.main(
+                        args,
+                        prog_name,
+                        complete_var,
+                        standalone_mode,
+                        windows_expand_args,
+                        **extra,
+                    )
+                except SystemExit as retry_exit:
+                    _after_command(command_info, success=(retry_exit.code in (None, 0)))
+                    raise
+                finally:
+                    self._retrying = False
+                _after_command(command_info, success=True)
             else:
-                # this happens in self.main
-                # so the above is still correct
+                if not self._retrying:
+                    _after_command(command_info, success=False, error=e)
                 if not args:
                     args = sys.argv[1:]
                 cmd = " ".join(args or [])

--- a/src/anaconda_cli_base/config.py
+++ b/src/anaconda_cli_base/config.py
@@ -71,12 +71,27 @@ class AnacondaConfigTomlSettingsSource(PyprojectTomlConfigSettingsSource):
 
 class AnacondaBaseSettings(BaseSettings):
     def __init_subclass__(
-        cls, plugin_name: Optional[Union[str, tuple]] = None, **kwargs: Any
+        cls,
+        plugin_name: Optional[Union[str, tuple]] = None,
+        table_name: Optional[str] = None,
+        **kwargs: Any,
     ) -> None:
         base_env_prefix: str = "ANACONDA_"
         pyproject_toml_table_header: Tuple[str, ...]
 
-        if plugin_name is None:
+        if plugin_name is not None and table_name is not None:
+            raise ValueError(
+                "Cannot specify both plugin_name and table_name. "
+                "Use plugin_name for [plugin.<name>] tables or "
+                "table_name for top-level [<name>] tables."
+            )
+
+        if table_name is not None:
+            # Top-level table: [telemetry], [auth], etc.
+            # No "plugin." prefix — for framework-level config sections.
+            pyproject_toml_table_header = (table_name,)
+            env_prefix = base_env_prefix + f"{table_name.upper()}_"
+        elif plugin_name is None:
             pyproject_toml_table_header = ()
             env_prefix = base_env_prefix
         elif isinstance(plugin_name, tuple):

--- a/src/anaconda_cli_base/plugins.py
+++ b/src/anaconda_cli_base/plugins.py
@@ -24,6 +24,8 @@ from anaconda_cli_base import __version__
 
 log = logging.getLogger(__name__)
 
+loaded_plugin_versions: Set[Tuple[str, str]] = set()
+
 PLUGIN_GROUP_NAME = "anaconda_cli.subcommand"
 
 # Plugins which are available but hidden from help text
@@ -279,6 +281,7 @@ def _sort_selectors(
 
 def load_registered_subcommands(app: typer.Typer) -> None:
     """Load all subcommands from plugins."""
+    global loaded_plugin_versions
     subcommand_entry_points = _load_entry_points_for_group(PLUGIN_GROUP_NAME)
     auth_handlers: Dict[PluginName, typer.Typer] = {}
     auth_handler_selectors: List[Tuple[SiteName, SiteDisplayName]] = []
@@ -320,6 +323,8 @@ def load_registered_subcommands(app: typer.Typer) -> None:
             name,
             value,
         )
+
+    loaded_plugin_versions = plugin_versions
 
     @app.command("versions", hidden=True)
     def versions() -> None:

--- a/src/anaconda_cli_base/plugins.py
+++ b/src/anaconda_cli_base/plugins.py
@@ -24,8 +24,6 @@ from anaconda_cli_base import __version__
 
 log = logging.getLogger(__name__)
 
-loaded_plugin_versions: Set[Tuple[str, str]] = set()
-
 PLUGIN_GROUP_NAME = "anaconda_cli.subcommand"
 
 # Plugins which are available but hidden from help text
@@ -281,7 +279,6 @@ def _sort_selectors(
 
 def load_registered_subcommands(app: typer.Typer) -> None:
     """Load all subcommands from plugins."""
-    global loaded_plugin_versions
     subcommand_entry_points = _load_entry_points_for_group(PLUGIN_GROUP_NAME)
     auth_handlers: Dict[PluginName, typer.Typer] = {}
     auth_handler_selectors: List[Tuple[SiteName, SiteDisplayName]] = []
@@ -323,8 +320,6 @@ def load_registered_subcommands(app: typer.Typer) -> None:
             name,
             value,
         )
-
-    loaded_plugin_versions = plugin_versions
 
     @app.command("versions", hidden=True)
     def versions() -> None:

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 AttributeValue = Union[str, bool, int, float, Sequence[Union[str, bool, int, float]]]
 
 _initialized = False
+_flush_timeout_ms = 500
 
 _suppress_http: ContextVar[bool] = ContextVar("_suppress_http", default=False)
 
@@ -45,7 +46,7 @@ def _is_enabled() -> bool:
 
 
 def _ensure_initialized() -> None:
-    global _initialized
+    global _initialized, _flush_timeout_ms
     if _initialized or not _is_enabled():
         return
     try:
@@ -92,6 +93,7 @@ def _ensure_initialized() -> None:
             attributes=attrs,
             signal_types=["metrics", "tracing"],
         )
+        _flush_timeout_ms = cfg.flush_timeout_ms
         _initialized = True
     except ImportError:
         # anaconda-opentelemetry not installed — expected in environments
@@ -157,20 +159,17 @@ def _after_command(
     _shutdown_telemetry()
 
 
-_FLUSH_TIMEOUT_MS = 500
-
-
 def _shutdown_telemetry() -> None:
     try:
         from opentelemetry import trace, metrics
 
         trace_provider = trace.get_tracer_provider()
         if hasattr(trace_provider, "shutdown"):
-            trace_provider.shutdown(timeout_millis=_FLUSH_TIMEOUT_MS)
+            trace_provider.shutdown(timeout_millis=_flush_timeout_ms)
 
         meter_provider = metrics.get_meter_provider()
         if hasattr(meter_provider, "shutdown"):
-            meter_provider.shutdown(timeout_millis=_FLUSH_TIMEOUT_MS)
+            meter_provider.shutdown(timeout_millis=_flush_timeout_ms)
     except Exception:
         pass
 

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -69,7 +69,7 @@ def _ensure_initialized() -> None:
 
         config = Configuration(
             default_endpoint=endpoint,
-            default_auth_token=api_key,
+            default_auth_token=api_key,  # type: ignore[arg-type]  # upstream accepts None despite annotation
         )
         config.set_skip_internet_check(True)
         if cfg.proxy_url:

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -161,19 +161,17 @@ def _after_command(
 
 def _shutdown_telemetry() -> None:
     try:
-        from opentelemetry import trace, metrics, _logs
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry import trace, metrics
 
         trace_provider = trace.get_tracer_provider()
-        if hasattr(trace_provider, "shutdown"):
+        if isinstance(trace_provider, TracerProvider):
             trace_provider.shutdown(timeout_millis=_flush_timeout_ms)
 
         meter_provider = metrics.get_meter_provider()
-        if hasattr(meter_provider, "shutdown"):
+        if isinstance(meter_provider, MeterProvider):
             meter_provider.shutdown(timeout_millis=_flush_timeout_ms)
-
-        logger_provider = _logs.get_logger_provider()
-        if hasattr(logger_provider, "shutdown"):
-            logger_provider.shutdown(timeout_millis=_flush_timeout_ms)
     except Exception:
         pass
 

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -1,12 +1,24 @@
 """Centralized telemetry for the Anaconda CLI framework.
 
-All functions are safe to call regardless of whether telemetry is configured.
-When no endpoint is set, every function is a no-op. Actual imports of the
-OTel SDK are deferred until telemetry is enabled to keep CLI startup fast.
+Plugin authors use module-level functions with plugin_name:
+
+    from anaconda_cli_base.telemetry import count, histogram, traced, log_event
+
+    count("models_downloaded", plugin_name="ai")
+    histogram("download_size_bytes", plugin_name="ai", value=result.size)
+    log_event("download complete", event_name="model_downloaded", plugin_name="ai")
+
+    with traced("models_download", plugin_name="ai") as span:
+        ...
+
+All functions are no-ops when telemetry is disabled or anaconda-opentelemetry
+is not installed.
 """
 
 import logging
 import os
+import sys
+import threading
 import time
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
@@ -15,14 +27,26 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any, Dict, Optional, Union
 
+from anaconda_cli_base.telemetry_config import (
+    TelemetryConfig,
+    AUTHENTICATED_ENDPOINT,
+    PUBLIC_ENDPOINT,
+)
+
 logger = logging.getLogger(__name__)
 
 AttributeValue = Union[str, bool, int, float, Sequence[Union[str, bool, int, float]]]
 
-_initialized = False
-_flush_timeout_ms = 500
+config = TelemetryConfig()
 
+_lock = threading.Lock()
+_backend_initialized = False
 _suppress_http: ContextVar[bool] = ContextVar("_suppress_http", default=False)
+
+
+# ---------------------------------------------------------------------------
+# Environment detection helpers
+# ---------------------------------------------------------------------------
 
 
 @lru_cache(maxsize=1)
@@ -58,20 +82,6 @@ def _detect_ci_vendor() -> str:
     return ""
 
 
-def _is_first_run() -> bool:
-    from pathlib import Path
-
-    marker = Path.home() / ".anaconda" / ".telemetry_initialized"
-    if marker.exists():
-        return False
-    try:
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.touch()
-    except OSError:
-        pass
-    return True
-
-
 def _detect_ai_agent() -> str:
     indicators = {
         "CURSOR_TRACE_ID": "cursor",
@@ -93,9 +103,257 @@ def _detect_ai_agent() -> str:
 
 
 def _detect_tty() -> bool:
-    import sys
-
     return sys.stdout.isatty()
+
+
+def _is_first_run() -> bool:
+    from pathlib import Path
+
+    marker = Path.home() / ".anaconda" / ".telemetry_initialized"
+    if marker.exists():
+        return False
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+    except OSError:
+        pass
+    return True
+
+
+def _get_api_key() -> Optional[str]:
+    try:
+        from anaconda_auth.token import TokenInfo
+
+        token_info = TokenInfo.load("anaconda.com")
+        return token_info.api_key
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Backend lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _init_backend() -> None:
+    global _backend_initialized
+    if _backend_initialized:
+        return
+    with _lock:
+        if _backend_initialized:
+            return
+        if not config.enabled:
+            return
+        try:
+            os.environ.setdefault("GRPC_VERBOSITY", "NONE")
+
+            import re
+            import platform as platform_mod
+
+            from anaconda_opentelemetry.config import Configuration
+            from anaconda_opentelemetry.attributes import ResourceAttributes
+            from anaconda_opentelemetry.signals import initialize_telemetry
+
+            from anaconda_cli_base import __version__
+
+            api_key = _get_api_key()
+            if config.endpoint:
+                endpoint = config.endpoint
+            elif api_key:
+                endpoint = AUTHENTICATED_ENDPOINT
+            else:
+                endpoint = PUBLIC_ENDPOINT
+
+            otel_config = Configuration(
+                default_endpoint=endpoint,
+                default_auth_token=api_key,  # type: ignore[arg-type]
+            )
+            otel_config.set_skip_internet_check(True)
+            if config.proxy_url:
+                otel_config.set_proxy_url(config.proxy_url)
+
+            otel_config.set_metrics_export_interval_ms(1000)
+            otel_config.set_tracing_export_interval_ms(1000)
+
+            service_version = re.sub(r"[^a-zA-Z0-9._-]", ".", __version__)[:30]
+
+            attrs = ResourceAttributes(
+                service_name="anaconda-cli-base",
+                service_version=service_version,
+                platform=f"{platform_mod.system().lower()}-{platform_mod.machine()}",
+                environment="production",
+                anon_usage=config.share_session_identity,
+            )
+            attrs.set_attributes(
+                plugin_versions=_get_plugin_versions(),
+                ci_vendor=_detect_ci_vendor(),
+                auth_state="authenticated" if api_key else "anonymous",
+                is_first_run=_is_first_run(),
+                ai_agent=_detect_ai_agent(),
+                is_tty=_detect_tty(),
+            )
+            initialize_telemetry(
+                config=otel_config,
+                attributes=attrs,
+                signal_types=["logging", "metrics", "tracing"],
+            )
+            _backend_initialized = True
+        except ImportError:
+            pass
+        except Exception as exc:
+            logger.debug("Telemetry initialization failed: %s", exc)
+
+
+def shutdown() -> None:
+    if not _backend_initialized:
+        return
+    try:
+        import atexit
+
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry import trace, metrics
+
+        from anaconda_opentelemetry.logging import _AnacondaLogger
+
+        flush_timeout = config.flush_timeout_ms
+
+        trace_provider = trace.get_tracer_provider()
+        if isinstance(trace_provider, TracerProvider):
+            trace_provider.force_flush(timeout_millis=flush_timeout)
+            if trace_provider._atexit_handler is not None:
+                atexit.unregister(trace_provider._atexit_handler)
+                trace_provider._atexit_handler = None
+
+        meter_provider = metrics.get_meter_provider()
+        if isinstance(meter_provider, MeterProvider):
+            meter_provider.force_flush(timeout_millis=flush_timeout)
+            if meter_provider._atexit_handler is not None:
+                atexit.unregister(meter_provider._atexit_handler)
+                meter_provider._atexit_handler = None
+
+        if _AnacondaLogger._instance is not None:
+            logger_provider = _AnacondaLogger._instance._provider
+            if isinstance(logger_provider, LoggerProvider):
+                logger_provider.force_flush(timeout_millis=flush_timeout)
+                if logger_provider._at_exit_handler is not None:
+                    atexit.unregister(logger_provider._at_exit_handler)
+                    logger_provider._at_exit_handler = None
+    except Exception:
+        pass
+
+
+def is_enabled() -> bool:
+    return _backend_initialized
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def traced(
+    name: str, *, plugin_name: str, attributes: Optional[Dict[str, Any]] = None
+) -> Generator[Any, None, None]:
+    _init_backend()
+    if not _backend_initialized:
+        yield _NoOpSpan()
+        return
+    try:
+        from anaconda_opentelemetry import get_trace
+
+        with get_trace(name, attributes=_build_attrs(attributes, plugin_name)) as span:
+            yield span
+    except Exception:
+        yield _NoOpSpan()
+
+
+def count(
+    name: str,
+    *,
+    plugin_name: str,
+    value: int = 1,
+    attributes: Optional[Dict[str, Any]] = None,
+) -> None:
+    _init_backend()
+    if not _backend_initialized:
+        return
+    try:
+        from anaconda_opentelemetry import increment_counter
+
+        increment_counter(
+            name, by=value, attributes=_build_attrs(attributes, plugin_name)
+        )
+    except Exception:
+        pass
+
+
+def histogram(
+    name: str,
+    *,
+    plugin_name: str,
+    value: float,
+    attributes: Optional[Dict[str, Any]] = None,
+) -> None:
+    _init_backend()
+    if not _backend_initialized:
+        return
+    try:
+        from anaconda_opentelemetry import record_histogram
+
+        record_histogram(name, value, attributes=_build_attrs(attributes, plugin_name))
+    except Exception:
+        pass
+
+
+def log_event(
+    body: str,
+    *,
+    event_name: str,
+    plugin_name: str,
+    attributes: Optional[Dict[str, Any]] = None,
+) -> None:
+    _init_backend()
+    if not _backend_initialized:
+        return
+    try:
+        from anaconda_opentelemetry.signals import send_event
+
+        send_event(body, event_name, attributes=_build_attrs(attributes, plugin_name))
+    except Exception:
+        pass
+
+
+def get_otel_handler(level: int = logging.WARNING) -> logging.Handler:
+    _init_backend()
+    if not _backend_initialized:
+        return logging.NullHandler()
+    try:
+        from anaconda_opentelemetry.signals import get_telemetry_logger_handler
+
+        handler = get_telemetry_logger_handler()
+        if handler is None:
+            return logging.NullHandler()
+        handler.setLevel(level)
+        return handler
+    except Exception:
+        return logging.NullHandler()
+
+
+def _build_attrs(
+    attributes: Optional[Dict[str, Any]], plugin_name: str
+) -> Dict[str, Any]:
+    attrs = dict(attributes or {})
+    attrs["source"] = "anaconda-cli-base"
+    attrs["plugin"] = plugin_name
+    return attrs
+
+
+# ---------------------------------------------------------------------------
+# CLI framework internals
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -106,117 +364,11 @@ class _CommandInfo:
     start_time: float = field(default_factory=time.perf_counter)
 
 
-def _is_enabled() -> bool:
-    # Early-exit: OTel SDK checks this deeper in the stack, but catching it here
-    # avoids reading config.toml and importing anaconda-opentelemetry for nothing.
-    if os.environ.get("OTEL_SDK_DISABLED", "").lower() in ("true", "1", "yes"):
-        return False
-    try:
-        from anaconda_cli_base.telemetry_config import TelemetryConfig
-
-        cfg = TelemetryConfig()
-        return cfg.enabled
-    except Exception:
-        return False
-
-
-def _ensure_initialized() -> None:
-    global _initialized, _flush_timeout_ms
-    if _initialized or not _is_enabled():
-        return
-    try:
-        os.environ.setdefault("GRPC_VERBOSITY", "NONE")
-
-        from anaconda_opentelemetry.config import Configuration
-        from anaconda_opentelemetry.attributes import ResourceAttributes
-        from anaconda_opentelemetry.signals import initialize_telemetry
-
-        import re
-
-        from anaconda_cli_base import __version__
-        from anaconda_cli_base.telemetry_config import (
-            TelemetryConfig,
-            AUTHENTICATED_ENDPOINT,
-            PUBLIC_ENDPOINT,
-        )
-
-        cfg = TelemetryConfig()
-
-        api_key = _get_api_key()
-        if cfg.endpoint:
-            endpoint = cfg.endpoint
-        elif api_key:
-            endpoint = AUTHENTICATED_ENDPOINT
-        else:
-            endpoint = PUBLIC_ENDPOINT
-
-        config = Configuration(
-            default_endpoint=endpoint,
-            default_auth_token=api_key,  # type: ignore[arg-type]  # upstream accepts None despite annotation
-        )
-        config.set_skip_internet_check(True)
-        if cfg.proxy_url:
-            config.set_proxy_url(cfg.proxy_url)
-
-        config.set_metrics_export_interval_ms(1000)
-        config.set_tracing_export_interval_ms(1000)
-
-        import platform as platform_mod
-
-        service_version = re.sub(r"[^a-zA-Z0-9._-]", ".", __version__)[:30]
-
-        attrs = ResourceAttributes(
-            service_name="anaconda-cli-base",
-            service_version=service_version,
-            platform=f"{platform_mod.system().lower()}-{platform_mod.machine()}",
-            environment="production",
-            anon_usage=cfg.share_session_identity,
-        )
-        attrs.set_attributes(
-            plugin_versions=_get_plugin_versions(),
-            ci_vendor=_detect_ci_vendor(),
-            auth_state="authenticated" if api_key else "anonymous",
-            is_first_run=_is_first_run(),
-            ai_agent=_detect_ai_agent(),
-            is_tty=_detect_tty(),
-        )
-        initialize_telemetry(
-            config=config,
-            attributes=attrs,
-            signal_types=["logging", "metrics", "tracing"],
-        )
-        _flush_timeout_ms = cfg.flush_timeout_ms
-        _initialized = True
-    except ImportError:
-        # anaconda-opentelemetry not installed — expected in environments
-        # without the [telemetry] extra.
-        pass
-    except Exception as exc:
-        # SDK is installed but initialization failed (bad endpoint, auth,
-        # version mismatch, etc.). Never surface to end users — telemetry
-        # must fail silently. Diagnosable only at DEBUG level.
-        logger.debug("Telemetry initialization failed: %s", exc)
-
-
-def _get_api_key() -> Optional[str]:
-    try:
-        from anaconda_auth.exceptions import TokenNotFoundError
-        from anaconda_auth.token import TokenInfo
-
-        token_info = TokenInfo.load("anaconda.com")
-        return token_info.api_key
-    except TokenNotFoundError:
-        return None
-    except Exception:
-        return None
-
-
 def _before_command(
     args: Optional[Sequence[str]], prog_name: Optional[str]
 ) -> Optional[_CommandInfo]:
-    """Start tracking a command. Returns None when telemetry is inactive."""
-    _ensure_initialized()
-    if not _initialized:
+    _init_backend()
+    if not _backend_initialized:
         return None
     command_name = " ".join(args[:2]) if args else prog_name or "unknown"
     plugin_name = args[0] if args else "root"
@@ -257,223 +409,16 @@ def _after_command(
     except Exception:
         pass
 
-    _shutdown_telemetry()
+    shutdown()
 
 
-def _shutdown_telemetry() -> None:
-    """Flush all telemetry and disable atexit handlers to prevent exit hangs."""
-    try:
-        import atexit
-
-        from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.metrics import MeterProvider
-        from opentelemetry.sdk._logs import LoggerProvider
-        from opentelemetry import trace, metrics
-
-        from anaconda_opentelemetry.logging import _AnacondaLogger
-
-        trace_provider = trace.get_tracer_provider()
-        if isinstance(trace_provider, TracerProvider):
-            trace_provider.force_flush(timeout_millis=_flush_timeout_ms)
-            if trace_provider._atexit_handler is not None:
-                atexit.unregister(trace_provider._atexit_handler)
-                trace_provider._atexit_handler = None
-
-        meter_provider = metrics.get_meter_provider()
-        if isinstance(meter_provider, MeterProvider):
-            meter_provider.force_flush(timeout_millis=_flush_timeout_ms)
-            if meter_provider._atexit_handler is not None:
-                atexit.unregister(meter_provider._atexit_handler)
-                meter_provider._atexit_handler = None
-
-        if _AnacondaLogger._instance is not None:
-            logger_provider = _AnacondaLogger._instance._provider
-            if isinstance(logger_provider, LoggerProvider):
-                logger_provider.force_flush(timeout_millis=_flush_timeout_ms)
-                if logger_provider._at_exit_handler is not None:
-                    atexit.unregister(logger_provider._at_exit_handler)
-                    logger_provider._at_exit_handler = None
-    except Exception:
-        pass
-
-
-def is_telemetry_enabled() -> bool:
-    return _initialized
-
-
-def get_otel_handler(level: int = logging.WARNING) -> logging.Handler:
-    """Get a logging handler that exports log records to the OTel backend.
-
-    Attach to any named logger to forward records at *level* or above to the
-    telemetry collector. The handler is additive — existing handlers (stderr,
-    file) continue to work normally.
-
-    Returns a NullHandler when telemetry is inactive or unavailable, so it is
-    always safe to call unconditionally.
-
-    Usage:
-        import logging
-        from anaconda_cli_base.telemetry import get_otel_handler
-
-        log = logging.getLogger("anaconda_ai")
-        log.addHandler(get_otel_handler())
-
-        # Only WARNING+ goes to OTel; all levels still go to other handlers
-        log.error("download failed", extra={"model": model, "error.type": "TimeoutError"})
-    """
-    if not _initialized:
-        return logging.NullHandler()
-    try:
-        from anaconda_opentelemetry.signals import get_telemetry_logger_handler
-
-        handler = get_telemetry_logger_handler()
-        if handler is None:
-            return logging.NullHandler()
-        handler.setLevel(level)
-        return handler
-    except Exception:
-        return logging.NullHandler()
-
-
-@contextmanager
-def traced(
-    name: str,
-    plugin_name: str,
-    attributes: Optional[Dict[str, Any]] = None,
-) -> Generator[Any, None, None]:
-    """Create a child span for tracing a block of work.
-
-    Use to measure duration and capture events within a logical operation.
-    The span appears in trace views as a child of the CLI command's root span,
-    giving visibility into where time is spent.
-
-    Usage:
-        with traced("models_download", plugin_name="ai", attributes={"model": "llama3"}) as span:
-            result = do_download(model)
-            span.add_event("download_complete", {"size_bytes": result.size})
-    """
-    if not _initialized:
-        _ensure_initialized()
-    if not _initialized:
-        yield _NoOpSpan()
-        return
-    try:
-        from anaconda_opentelemetry import get_trace
-
-        span_attrs = _build_attrs(attributes, plugin_name)
-        with get_trace(name, attributes=span_attrs) as span:
-            yield span
-    except Exception:
-        # Defensive: upstream get_trace() does `return None` inside a @contextmanager
-        # when tracing is uninitialized, which breaks the `with` protocol.
-        yield _NoOpSpan()
-
-
-def count(
-    name: str,
-    plugin_name: str,
-    value: int = 1,
-    attributes: Optional[Dict[str, Any]] = None,
-) -> None:
-    """Increment a counter metric. Use for discrete occurrences you want to sum.
-
-    Counters are aggregated server-side (summed over time windows) and are ideal
-    for alerting on rates (e.g., errors/minute). Use instead of log_event when
-    you need numeric aggregation rather than individual event records.
-
-    Examples: commands executed, models downloaded, auth failures.
-    """
-    if not _initialized:
-        _ensure_initialized()
-    if not _initialized:
-        return
-    try:
-        from anaconda_opentelemetry import increment_counter
-
-        increment_counter(
-            name, by=value, attributes=_build_attrs(attributes, plugin_name)
-        )
-    except Exception:
-        pass
-
-
-def histogram(
-    name: str,
-    plugin_name: str,
-    value: float,
-    attributes: Optional[Dict[str, Any]] = None,
-) -> None:
-    """Record a distribution measurement. Use for values you want percentiles of.
-
-    Histograms compute p50/p95/p99 server-side, making them ideal for latency
-    and size measurements. Use instead of log_event when you need statistical
-    summaries rather than individual event records.
-
-    Examples: command duration, download size, response time.
-    """
-    if not _initialized:
-        _ensure_initialized()
-    if not _initialized:
-        return
-    try:
-        from anaconda_opentelemetry import record_histogram
-
-        record_histogram(name, value, attributes=_build_attrs(attributes, plugin_name))
-    except Exception:
-        pass
-
-
-def log_event(
-    body: str,
-    event_name: str,
-    plugin_name: str,
-    attributes: Optional[Dict[str, Any]] = None,
-) -> None:
-    """Send a structured log event. No-ops when telemetry is disabled.
-
-    Note: Unlike increment_counter/record_histogram (which return False when
-    uninitialized), the upstream send_event() raises RuntimeError. The broad
-    except here is intentional — it ensures the CLI never crashes due to
-    telemetry, even if _initialized becomes stale or the upstream behavior
-    changes.
-    """
-    if not _initialized:
-        _ensure_initialized()
-    if not _initialized:
-        return
-    try:
-        from anaconda_opentelemetry.signals import send_event
-
-        send_event(body, event_name, attributes=_build_attrs(attributes, plugin_name))
-    except Exception:
-        pass
-
-
-def _build_attrs(
-    attributes: Optional[Dict[str, Any]], plugin_name: str
-) -> Dict[str, Any]:
-    attrs = dict(attributes or {})
-    attrs["source"] = "anaconda-cli-base"
-    attrs["plugin"] = plugin_name
-    return attrs
+# ---------------------------------------------------------------------------
+# HTTP span suppression
+# ---------------------------------------------------------------------------
 
 
 @contextmanager
 def suppress_http_spans() -> Generator[None, None, None]:
-    """Suppress HTTP-level spans inside a block to reduce trace noise.
-
-    Use when polling or retrying produces many identical HTTP spans that
-    obscure the real operation. The parent span still records full duration,
-    and HTTP metrics (counters/histograms) are still emitted — only spans
-    are suppressed.
-
-    Usage:
-        with traced("servers_wait_for_running") as span:
-            with suppress_http_spans():
-                while status != "running":
-                    status = client.servers.status(server_id)
-            span.add_attributes({"final_status": status})
-    """
     token = _suppress_http.set(True)
     try:
         yield
@@ -483,6 +428,11 @@ def suppress_http_spans() -> Generator[None, None, None]:
 
 def is_http_suppressed() -> bool:
     return _suppress_http.get()
+
+
+# ---------------------------------------------------------------------------
+# NoOp span
+# ---------------------------------------------------------------------------
 
 
 class _NoOpSpan:

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -1,0 +1,275 @@
+"""Centralized telemetry for the Anaconda CLI framework.
+
+All functions are safe to call regardless of whether telemetry is configured.
+When no endpoint is set, every function is a no-op. Actual imports of the
+OTel SDK are deferred until telemetry is enabled to keep CLI startup fast.
+"""
+
+import os
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+_initialized = False
+
+_suppress_http: ContextVar[bool] = ContextVar("_suppress_http", default=False)
+
+
+@dataclass
+class _CommandInfo:
+    command: str
+    plugin: str
+    start_time: float = field(default_factory=time.perf_counter)
+
+
+def _is_enabled() -> bool:
+    # Early-exit: OTel SDK checks this deeper in the stack, but catching it here
+    # avoids reading config.toml and importing anaconda-opentelemetry for nothing.
+    if os.environ.get("OTEL_SDK_DISABLED", "").lower() in ("true", "1", "yes"):
+        return False
+    try:
+        from anaconda_cli_base.telemetry_config import TelemetryConfig
+
+        cfg = TelemetryConfig()
+        return bool(cfg.endpoint)
+    except Exception:
+        return False
+
+
+def _ensure_initialized() -> None:
+    global _initialized
+    if _initialized or not _is_enabled():
+        return
+    try:
+        from anaconda_opentelemetry import (
+            Configuration,
+            ResourceAttributes,
+            initialize_telemetry,
+        )
+
+        from anaconda_cli_base import __version__
+        from anaconda_cli_base.telemetry_config import TelemetryConfig
+
+        cfg = TelemetryConfig()
+
+        api_key = None
+        try:
+            from anaconda_auth.config import AnacondaAuthConfig
+
+            api_key = AnacondaAuthConfig().api_key
+        except Exception:
+            pass
+
+        config = Configuration(
+            default_endpoint=cfg.endpoint,
+            default_auth_token=api_key,
+        )
+        if cfg.skip_internet_check:
+            config.set_skip_internet_check(True)
+
+        config.set_metrics_export_interval_ms(1000)
+        config.set_tracing_export_interval_ms(1000)
+
+        attrs = ResourceAttributes(
+            service_name="anaconda-cli-base",
+            service_version=__version__,
+            environment="",
+            anon_usage=cfg.anon_usage,
+        )
+        initialize_telemetry(
+            config=config,
+            attributes=attrs,
+            signal_types=["metrics", "tracing"],
+        )
+        _initialized = True
+    except Exception:
+        pass
+
+
+def _before_command(args, prog_name) -> Optional[_CommandInfo]:
+    _ensure_initialized()
+    if not _initialized:
+        return None
+    command_name = " ".join(args[:2]) if args else prog_name or "unknown"
+    plugin_name = args[0] if args else "root"
+    return _CommandInfo(command=command_name, plugin=plugin_name)
+
+
+def _after_command(
+    info: Optional[_CommandInfo], success: bool, error: Optional[Exception] = None
+) -> None:
+    if info is None:
+        return
+    try:
+        from anaconda_opentelemetry import increment_counter, record_histogram
+
+        duration_ms = (time.perf_counter() - info.start_time) * 1000
+        attrs = {
+            "command": info.command,
+            "plugin": info.plugin,
+            "source": "anaconda-cli-base",
+        }
+
+        record_histogram("cli_command_duration_ms", duration_ms, attrs)
+        increment_counter("cli_command_invoked", attributes=attrs)
+        if not success:
+            error_attrs = {
+                **attrs,
+                "error.type": type(error).__name__ if error else "unknown",
+            }
+            increment_counter("cli_command_errors", attributes=error_attrs)
+    except Exception:
+        pass
+
+    _shutdown_telemetry()
+
+
+_FLUSH_TIMEOUT_MS = 500
+
+
+def _shutdown_telemetry() -> None:
+    try:
+        from opentelemetry import trace, metrics
+
+        trace_provider = trace.get_tracer_provider()
+        if hasattr(trace_provider, "shutdown"):
+            trace_provider.shutdown(timeout_millis=_FLUSH_TIMEOUT_MS)
+
+        meter_provider = metrics.get_meter_provider()
+        if hasattr(meter_provider, "shutdown"):
+            meter_provider.shutdown(timeout_millis=_FLUSH_TIMEOUT_MS)
+    except Exception:
+        pass
+
+
+def is_telemetry_enabled() -> bool:
+    return _initialized
+
+
+@contextmanager
+def traced(
+    name: str,
+    attributes: Optional[Dict[str, Any]] = None,
+    source: Optional[str] = None,
+):
+    """Create a traced span. No-ops when telemetry is disabled.
+
+    The except clause yielding _NoOpSpan is defensive against an upstream
+    bug in anaconda-opentelemetry's get_trace(): when tracing is not
+    initialized, it does `return None` inside a @contextmanager generator
+    instead of yielding, which causes a TypeError/StopIteration. This wrapper
+    guarantees callers always get a usable span object.
+    """
+    if not _initialized:
+        yield _NoOpSpan()
+        return
+    try:
+        from anaconda_opentelemetry import get_trace
+
+        span_attrs = dict(attributes or {})
+        if source:
+            span_attrs["source"] = source
+        with get_trace(name, attributes=span_attrs) as span:
+            yield span
+    except Exception:
+        yield _NoOpSpan()
+
+
+def count(
+    name: str,
+    by: int = 1,
+    attributes: Optional[Dict[str, Any]] = None,
+    source: Optional[str] = None,
+) -> None:
+    if not _initialized:
+        return
+    try:
+        from anaconda_opentelemetry import increment_counter
+
+        metric_attrs = dict(attributes or {})
+        if source:
+            metric_attrs["source"] = source
+        increment_counter(name, by=by, attributes=metric_attrs)
+    except Exception:
+        pass
+
+
+def histogram(
+    name: str,
+    value: float,
+    attributes: Optional[Dict[str, Any]] = None,
+    source: Optional[str] = None,
+) -> None:
+    if not _initialized:
+        return
+    try:
+        from anaconda_opentelemetry import record_histogram
+
+        metric_attrs = dict(attributes or {})
+        if source:
+            metric_attrs["source"] = source
+        record_histogram(name, value, attributes=metric_attrs)
+    except Exception:
+        pass
+
+
+def log_event(
+    body: str,
+    event_name: str,
+    attributes: Optional[Dict[str, Any]] = None,
+    source: Optional[str] = None,
+) -> None:
+    """Send a structured log event. No-ops when telemetry is disabled.
+
+    Note: Unlike increment_counter/record_histogram (which return False when
+    uninitialized), the upstream send_event() raises RuntimeError. The broad
+    except here is intentional — it ensures the CLI never crashes due to
+    telemetry, even if _initialized becomes stale or the upstream behavior
+    changes.
+    """
+    if not _initialized:
+        return
+    try:
+        from anaconda_opentelemetry.signals import send_event
+
+        event_attrs = dict(attributes or {})
+        if source:
+            event_attrs["source"] = source
+        send_event(body, event_name, attributes=event_attrs)
+    except Exception:
+        pass
+
+
+@contextmanager
+def suppress_http_spans():
+    """Suppress HTTP-level spans inside this block.
+
+    Uses contextvars for proper isolation across threads and asyncio tasks.
+    The parent span (from traced()) still records the full duration.
+    HTTP metrics (counters/histograms) are still emitted — only spans are suppressed.
+    """
+    token = _suppress_http.set(True)
+    try:
+        yield
+    finally:
+        _suppress_http.reset(token)
+
+
+def is_http_suppressed() -> bool:
+    return _suppress_http.get()
+
+
+class _NoOpSpan:
+    def add_event(self, name: str, attributes=None):
+        pass
+
+    def add_exception(self, exc: Exception):
+        pass
+
+    def set_error_status(self, msg: Optional[str] = None):
+        pass
+
+    def add_attributes(self, attributes: dict):
+        pass

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -37,10 +37,46 @@ def _get_plugin_versions() -> Dict[str, str]:
     return versions
 
 
+def _detect_ci_vendor() -> str:
+    ci_env_vars = {
+        "GITHUB_ACTIONS": "github-actions",
+        "GITLAB_CI": "gitlab-ci",
+        "JENKINS_URL": "jenkins",
+        "CIRCLECI": "circleci",
+        "TRAVIS": "travis-ci",
+        "BUILDKITE": "buildkite",
+        "TF_BUILD": "azure-pipelines",
+        "CODEBUILD_BUILD_ID": "aws-codebuild",
+        "TEAMCITY_VERSION": "teamcity",
+        "BITBUCKET_PIPELINE_UUID": "bitbucket-pipelines",
+    }
+    for env_var, vendor in ci_env_vars.items():
+        if os.environ.get(env_var):
+            return vendor
+    if os.environ.get("CI"):
+        return "unknown-ci"
+    return ""
+
+
+def _is_first_run() -> bool:
+    from pathlib import Path
+
+    marker = Path.home() / ".anaconda" / ".telemetry_initialized"
+    if marker.exists():
+        return False
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+    except OSError:
+        pass
+    return True
+
+
 @dataclass
 class _CommandInfo:
     command: str
     plugin: str
+    flags: str
     start_time: float = field(default_factory=time.perf_counter)
 
 
@@ -110,7 +146,12 @@ def _ensure_initialized() -> None:
             environment="production",
             anon_usage=cfg.share_session_identity,
         )
-        attrs.set_attributes(plugin_versions=_get_plugin_versions())
+        attrs.set_attributes(
+            plugin_versions=_get_plugin_versions(),
+            ci_vendor=_detect_ci_vendor(),
+            auth_state="authenticated" if api_key else "anonymous",
+            is_first_run=_is_first_run(),
+        )
         initialize_telemetry(
             config=config,
             attributes=attrs,
@@ -151,11 +192,15 @@ def _before_command(
         return None
     command_name = " ".join(args[:2]) if args else prog_name or "unknown"
     plugin_name = args[0] if args else "root"
-    return _CommandInfo(command=command_name, plugin=plugin_name)
+    flags = ",".join(a.split("=")[0] for a in (args or []) if a.startswith("-"))
+    return _CommandInfo(command=command_name, plugin=plugin_name, flags=flags)
 
 
 def _after_command(
-    info: Optional[_CommandInfo], success: bool, error: Optional[Exception] = None
+    info: Optional[_CommandInfo],
+    success: bool,
+    error: Optional[Exception] = None,
+    exit_code: int = 0,
 ) -> None:
     if info is None:
         return
@@ -167,6 +212,8 @@ def _after_command(
             "command": info.command,
             "plugin": info.plugin,
             "source": "anaconda-cli-base",
+            "flags": info.flags,
+            "exit_code": exit_code if not success else 0,
         }
 
         record_histogram("cli_command_duration_ms", duration_ms, attrs)

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -56,6 +56,8 @@ def _ensure_initialized() -> None:
         from anaconda_opentelemetry.attributes import ResourceAttributes
         from anaconda_opentelemetry.signals import initialize_telemetry
 
+        import re
+
         from anaconda_cli_base import __version__
         from anaconda_cli_base.telemetry_config import (
             TelemetryConfig,
@@ -84,9 +86,11 @@ def _ensure_initialized() -> None:
         config.set_metrics_export_interval_ms(1000)
         config.set_tracing_export_interval_ms(1000)
 
+        service_version = re.sub(r"[^a-zA-Z0-9._-]", ".", __version__)[:30]
+
         attrs = ResourceAttributes(
             service_name="anaconda-cli-base",
-            service_version=__version__,
+            service_version=service_version,
             environment="",
             anon_usage=cfg.share_session_identity,
         )

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -33,7 +33,7 @@ def _is_enabled() -> bool:
         from anaconda_cli_base.telemetry_config import TelemetryConfig
 
         cfg = TelemetryConfig()
-        return bool(cfg.endpoint)
+        return cfg.enabled
     except Exception:
         return False
 
@@ -50,15 +50,19 @@ def _ensure_initialized() -> None:
         )
 
         from anaconda_cli_base import __version__
-        from anaconda_cli_base.telemetry_config import TelemetryConfig
+        from anaconda_cli_base.telemetry_config import (
+            TelemetryConfig,
+            AUTHENTICATED_ENDPOINT,
+            PUBLIC_ENDPOINT,
+        )
 
         cfg = TelemetryConfig()
 
         api_key = _get_api_key()
         if api_key:
-            endpoint = cfg.endpoint
+            endpoint = AUTHENTICATED_ENDPOINT
         else:
-            endpoint = cfg.public_endpoint
+            endpoint = PUBLIC_ENDPOINT
 
         config = Configuration(
             default_endpoint=endpoint,
@@ -74,7 +78,7 @@ def _ensure_initialized() -> None:
             service_name="anaconda-cli-base",
             service_version=__version__,
             environment="",
-            anon_usage=cfg.anon_usage,
+            anon_usage=cfg.share_session_identity,
         )
         initialize_telemetry(
             config=config,

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -162,8 +162,8 @@ def is_telemetry_enabled() -> bool:
 @contextmanager
 def traced(
     name: str,
+    plugin_name: str,
     attributes: Optional[Dict[str, Any]] = None,
-    source: Optional[str] = None,
 ):
     """Create a child span for tracing a block of work.
 
@@ -172,7 +172,7 @@ def traced(
     giving visibility into where time is spent.
 
     Usage:
-        with traced("models_download", {"model": "llama3"}, source="anaconda-ai") as span:
+        with traced("models_download", plugin_name="ai", attributes={"model": "llama3"}) as span:
             result = do_download(model)
             span.add_event("download_complete", {"size_bytes": result.size})
     """
@@ -182,9 +182,7 @@ def traced(
     try:
         from anaconda_opentelemetry import get_trace
 
-        span_attrs = dict(attributes or {})
-        if source:
-            span_attrs["source"] = source
+        span_attrs = _build_attrs(attributes, plugin_name)
         with get_trace(name, attributes=span_attrs) as span:
             yield span
     except Exception:
@@ -195,9 +193,9 @@ def traced(
 
 def count(
     name: str,
+    plugin_name: str,
     value: int = 1,
     attributes: Optional[Dict[str, Any]] = None,
-    source: Optional[str] = None,
 ) -> None:
     """Increment a counter metric. Use for discrete occurrences you want to sum.
 
@@ -212,19 +210,18 @@ def count(
     try:
         from anaconda_opentelemetry import increment_counter
 
-        metric_attrs = dict(attributes or {})
-        if source:
-            metric_attrs["source"] = source
-        increment_counter(name, by=value, attributes=metric_attrs)
+        increment_counter(
+            name, by=value, attributes=_build_attrs(attributes, plugin_name)
+        )
     except Exception:
         pass
 
 
 def histogram(
     name: str,
+    plugin_name: str,
     value: float,
     attributes: Optional[Dict[str, Any]] = None,
-    source: Optional[str] = None,
 ) -> None:
     """Record a distribution measurement. Use for values you want percentiles of.
 
@@ -239,10 +236,7 @@ def histogram(
     try:
         from anaconda_opentelemetry import record_histogram
 
-        metric_attrs = dict(attributes or {})
-        if source:
-            metric_attrs["source"] = source
-        record_histogram(name, value, attributes=metric_attrs)
+        record_histogram(name, value, attributes=_build_attrs(attributes, plugin_name))
     except Exception:
         pass
 
@@ -250,8 +244,8 @@ def histogram(
 def log_event(
     body: str,
     event_name: str,
+    plugin_name: str,
     attributes: Optional[Dict[str, Any]] = None,
-    source: Optional[str] = None,
 ) -> None:
     """Send a structured log event. No-ops when telemetry is disabled.
 
@@ -266,12 +260,18 @@ def log_event(
     try:
         from anaconda_opentelemetry.signals import send_event
 
-        event_attrs = dict(attributes or {})
-        if source:
-            event_attrs["source"] = source
-        send_event(body, event_name, attributes=event_attrs)
+        send_event(body, event_name, attributes=_build_attrs(attributes, plugin_name))
     except Exception:
         pass
+
+
+def _build_attrs(
+    attributes: Optional[Dict[str, Any]], plugin_name: str
+) -> Dict[str, Any]:
+    attrs = dict(attributes or {})
+    attrs["source"] = "anaconda-cli-base"
+    attrs["plugin"] = plugin_name
+    return attrs
 
 
 @contextmanager

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -7,10 +7,13 @@ OTel SDK are deferred until telemetry is enabled to keep CLI startup fast.
 
 import os
 import time
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
+
+AttributeValue = Union[str, bool, int, float, Sequence[Union[str, bool, int, float]]]
 
 _initialized = False
 
@@ -91,7 +94,7 @@ def _ensure_initialized() -> None:
         pass
 
 
-def _get_api_key():
+def _get_api_key() -> Optional[str]:
     try:
         from anaconda_auth.exceptions import TokenNotFoundError
         from anaconda_auth.token import TokenInfo
@@ -104,7 +107,9 @@ def _get_api_key():
         return None
 
 
-def _before_command(args, prog_name) -> Optional[_CommandInfo]:
+def _before_command(
+    args: Optional[Sequence[str]], prog_name: Optional[str]
+) -> Optional[_CommandInfo]:
     _ensure_initialized()
     if not _initialized:
         return None
@@ -122,7 +127,7 @@ def _after_command(
         from anaconda_opentelemetry import increment_counter, record_histogram
 
         duration_ms = (time.perf_counter() - info.start_time) * 1000
-        attrs = {
+        attrs: Dict[str, AttributeValue] = {
             "command": info.command,
             "plugin": info.plugin,
             "source": "anaconda-cli-base",
@@ -131,7 +136,7 @@ def _after_command(
         record_histogram("cli_command_duration_ms", duration_ms, attrs)
         increment_counter("cli_command_invoked", attributes=attrs)
         if not success:
-            error_attrs = {
+            error_attrs: Dict[str, AttributeValue] = {
                 **attrs,
                 "error.type": type(error).__name__ if error else "unknown",
             }
@@ -169,7 +174,7 @@ def traced(
     name: str,
     plugin_name: str,
     attributes: Optional[Dict[str, Any]] = None,
-):
+) -> Generator[Any, None, None]:
     """Create a child span for tracing a block of work.
 
     Use to measure duration and capture events within a logical operation.
@@ -280,7 +285,7 @@ def _build_attrs(
 
 
 @contextmanager
-def suppress_http_spans():
+def suppress_http_spans() -> Generator[None, None, None]:
     """Suppress HTTP-level spans inside a block to reduce trace noise.
 
     Use when polling or retrying produces many identical HTTP spans that
@@ -307,14 +312,14 @@ def is_http_suppressed() -> bool:
 
 
 class _NoOpSpan:
-    def add_event(self, name: str, attributes=None):
+    def add_event(self, name: str, attributes: Optional[Dict[str, Any]] = None) -> None:
         pass
 
-    def add_exception(self, exc: Exception):
+    def add_exception(self, exc: Exception) -> None:
         pass
 
-    def set_error_status(self, msg: Optional[str] = None):
+    def set_error_status(self, msg: Optional[str] = None) -> None:
         pass
 
-    def add_attributes(self, attributes: dict):
+    def add_attributes(self, attributes: Dict[str, Any]) -> None:
         pass

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -91,7 +91,7 @@ def _ensure_initialized() -> None:
         initialize_telemetry(
             config=config,
             attributes=attrs,
-            signal_types=["metrics", "tracing"],
+            signal_types=["logging", "metrics", "tracing"],
         )
         _flush_timeout_ms = cfg.flush_timeout_ms
         _initialized = True
@@ -161,7 +161,7 @@ def _after_command(
 
 def _shutdown_telemetry() -> None:
     try:
-        from opentelemetry import trace, metrics
+        from opentelemetry import trace, metrics, _logs
 
         trace_provider = trace.get_tracer_provider()
         if hasattr(trace_provider, "shutdown"):
@@ -170,12 +170,50 @@ def _shutdown_telemetry() -> None:
         meter_provider = metrics.get_meter_provider()
         if hasattr(meter_provider, "shutdown"):
             meter_provider.shutdown(timeout_millis=_flush_timeout_ms)
+
+        logger_provider = _logs.get_logger_provider()
+        if hasattr(logger_provider, "shutdown"):
+            logger_provider.shutdown(timeout_millis=_flush_timeout_ms)
     except Exception:
         pass
 
 
 def is_telemetry_enabled() -> bool:
     return _initialized
+
+
+def get_otel_handler(level: int = logging.WARNING) -> logging.Handler:
+    """Get a logging handler that exports log records to the OTel backend.
+
+    Attach to any named logger to forward records at *level* or above to the
+    telemetry collector. The handler is additive — existing handlers (stderr,
+    file) continue to work normally.
+
+    Returns a NullHandler when telemetry is inactive or unavailable, so it is
+    always safe to call unconditionally.
+
+    Usage:
+        import logging
+        from anaconda_cli_base.telemetry import get_otel_handler
+
+        log = logging.getLogger("anaconda_ai")
+        log.addHandler(get_otel_handler())
+
+        # Only WARNING+ goes to OTel; all levels still go to other handlers
+        log.error("download failed", extra={"model": model, "error.type": "TimeoutError"})
+    """
+    if not _initialized:
+        return logging.NullHandler()
+    try:
+        from anaconda_opentelemetry.signals import get_telemetry_logger_handler
+
+        handler = get_telemetry_logger_handler()
+        if handler is None:
+            return logging.NullHandler()
+        handler.setLevel(level)
+        return handler
+    except Exception:
+        return logging.NullHandler()
 
 
 @contextmanager

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -119,6 +119,7 @@ def _get_api_key() -> Optional[str]:
 def _before_command(
     args: Optional[Sequence[str]], prog_name: Optional[str]
 ) -> Optional[_CommandInfo]:
+    """Start tracking a command. Returns None when telemetry is inactive."""
     _ensure_initialized()
     if not _initialized:
         return None

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -158,18 +158,38 @@ def _after_command(
 
 
 def _shutdown_telemetry() -> None:
+    """Flush all telemetry and disable atexit handlers to prevent exit hangs."""
     try:
+        import atexit
+
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk._logs import LoggerProvider
         from opentelemetry import trace, metrics
+
+        from anaconda_opentelemetry.logging import _AnacondaLogger
 
         trace_provider = trace.get_tracer_provider()
         if isinstance(trace_provider, TracerProvider):
-            trace_provider.shutdown(timeout_millis=_flush_timeout_ms)
+            trace_provider.force_flush(timeout_millis=_flush_timeout_ms)
+            if trace_provider._atexit_handler is not None:
+                atexit.unregister(trace_provider._atexit_handler)
+                trace_provider._atexit_handler = None
 
         meter_provider = metrics.get_meter_provider()
         if isinstance(meter_provider, MeterProvider):
-            meter_provider.shutdown(timeout_millis=_flush_timeout_ms)
+            meter_provider.force_flush(timeout_millis=_flush_timeout_ms)
+            if meter_provider._atexit_handler is not None:
+                atexit.unregister(meter_provider._atexit_handler)
+                meter_provider._atexit_handler = None
+
+        if _AnacondaLogger._instance is not None:
+            logger_provider = _AnacondaLogger._instance._provider
+            if isinstance(logger_provider, LoggerProvider):
+                logger_provider.force_flush(timeout_millis=_flush_timeout_ms)
+                if logger_provider._at_exit_handler is not None:
+                    atexit.unregister(logger_provider._at_exit_handler)
+                    logger_provider._at_exit_handler = None
     except Exception:
         pass
 

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -165,13 +165,16 @@ def traced(
     attributes: Optional[Dict[str, Any]] = None,
     source: Optional[str] = None,
 ):
-    """Create a traced span. No-ops when telemetry is disabled.
+    """Create a child span for tracing a block of work.
 
-    The except clause yielding _NoOpSpan is defensive against an upstream
-    bug in anaconda-opentelemetry's get_trace(): when tracing is not
-    initialized, it does `return None` inside a @contextmanager generator
-    instead of yielding, which causes a TypeError/StopIteration. This wrapper
-    guarantees callers always get a usable span object.
+    Use to measure duration and capture events within a logical operation.
+    The span appears in trace views as a child of the CLI command's root span,
+    giving visibility into where time is spent.
+
+    Usage:
+        with traced("models_download", {"model": "llama3"}, source="anaconda-ai") as span:
+            result = do_download(model)
+            span.add_event("download_complete", {"size_bytes": result.size})
     """
     if not _initialized:
         yield _NoOpSpan()
@@ -185,15 +188,25 @@ def traced(
         with get_trace(name, attributes=span_attrs) as span:
             yield span
     except Exception:
+        # Defensive: upstream get_trace() does `return None` inside a @contextmanager
+        # when tracing is uninitialized, which breaks the `with` protocol.
         yield _NoOpSpan()
 
 
 def count(
     name: str,
-    by: int = 1,
+    value: int = 1,
     attributes: Optional[Dict[str, Any]] = None,
     source: Optional[str] = None,
 ) -> None:
+    """Increment a counter metric. Use for discrete occurrences you want to sum.
+
+    Counters are aggregated server-side (summed over time windows) and are ideal
+    for alerting on rates (e.g., errors/minute). Use instead of log_event when
+    you need numeric aggregation rather than individual event records.
+
+    Examples: commands executed, models downloaded, auth failures.
+    """
     if not _initialized:
         return
     try:
@@ -202,7 +215,7 @@ def count(
         metric_attrs = dict(attributes or {})
         if source:
             metric_attrs["source"] = source
-        increment_counter(name, by=by, attributes=metric_attrs)
+        increment_counter(name, by=value, attributes=metric_attrs)
     except Exception:
         pass
 
@@ -213,6 +226,14 @@ def histogram(
     attributes: Optional[Dict[str, Any]] = None,
     source: Optional[str] = None,
 ) -> None:
+    """Record a distribution measurement. Use for values you want percentiles of.
+
+    Histograms compute p50/p95/p99 server-side, making them ideal for latency
+    and size measurements. Use instead of log_event when you need statistical
+    summaries rather than individual event records.
+
+    Examples: command duration, download size, response time.
+    """
     if not _initialized:
         return
     try:
@@ -255,11 +276,19 @@ def log_event(
 
 @contextmanager
 def suppress_http_spans():
-    """Suppress HTTP-level spans inside this block.
+    """Suppress HTTP-level spans inside a block to reduce trace noise.
 
-    Uses contextvars for proper isolation across threads and asyncio tasks.
-    The parent span (from traced()) still records the full duration.
-    HTTP metrics (counters/histograms) are still emitted — only spans are suppressed.
+    Use when polling or retrying produces many identical HTTP spans that
+    obscure the real operation. The parent span still records full duration,
+    and HTTP metrics (counters/histograms) are still emitted — only spans
+    are suppressed.
+
+    Usage:
+        with traced("servers_wait_for_running") as span:
+            with suppress_http_spans():
+                while status != "running":
+                    status = client.servers.status(server_id)
+            span.add_attributes({"final_status": status})
     """
     token = _suppress_http.set(True)
     try:

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -276,6 +276,8 @@ def traced(
             span.add_event("download_complete", {"size_bytes": result.size})
     """
     if not _initialized:
+        _ensure_initialized()
+    if not _initialized:
         yield _NoOpSpan()
         return
     try:
@@ -305,6 +307,8 @@ def count(
     Examples: commands executed, models downloaded, auth failures.
     """
     if not _initialized:
+        _ensure_initialized()
+    if not _initialized:
         return
     try:
         from anaconda_opentelemetry import increment_counter
@@ -331,6 +335,8 @@ def histogram(
     Examples: command duration, download size, response time.
     """
     if not _initialized:
+        _ensure_initialized()
+    if not _initialized:
         return
     try:
         from anaconda_opentelemetry import record_histogram
@@ -354,6 +360,8 @@ def log_event(
     telemetry, even if _initialized becomes stale or the upstream behavior
     changes.
     """
+    if not _initialized:
+        _ensure_initialized()
     if not _initialized:
         return
     try:

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -50,11 +50,9 @@ def _ensure_initialized() -> None:
     if _initialized or not _is_enabled():
         return
     try:
-        from anaconda_opentelemetry import (
-            Configuration,
-            ResourceAttributes,
-            initialize_telemetry,
-        )
+        from anaconda_opentelemetry.config import Configuration
+        from anaconda_opentelemetry.attributes import ResourceAttributes
+        from anaconda_opentelemetry.signals import initialize_telemetry
 
         from anaconda_cli_base import __version__
         from anaconda_cli_base.telemetry_config import (

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -5,6 +5,7 @@ When no endpoint is set, every function is a no-op. Actual imports of the
 OTel SDK are deferred until telemetry is enabled to keep CLI startup fast.
 """
 
+import logging
 import os
 import time
 from collections.abc import Generator, Sequence
@@ -12,6 +13,8 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Union
+
+logger = logging.getLogger(__name__)
 
 AttributeValue = Union[str, bool, int, float, Sequence[Union[str, bool, int, float]]]
 
@@ -90,8 +93,14 @@ def _ensure_initialized() -> None:
             signal_types=["metrics", "tracing"],
         )
         _initialized = True
-    except Exception:
+    except ImportError:
+        # anaconda-opentelemetry not installed — expected in environments
+        # without the [telemetry] extra.
         pass
+    except Exception as exc:
+        # SDK is installed but initialization failed (bad endpoint, auth,
+        # version mismatch, etc.). Log so misconfiguration is diagnosable.
+        logger.warning("Telemetry enabled but failed to initialize: %s", exc)
 
 
 def _get_api_key() -> Optional[str]:

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -68,8 +68,9 @@ def _ensure_initialized() -> None:
             default_endpoint=endpoint,
             default_auth_token=api_key,
         )
-        if cfg.skip_internet_check:
-            config.set_skip_internet_check(True)
+        config.set_skip_internet_check(True)
+        if cfg.proxy_url:
+            config.set_proxy_url(cfg.proxy_url)
 
         config.set_metrics_export_interval_ms(1000)
         config.set_tracing_export_interval_ms(1000)

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -86,14 +86,22 @@ def _ensure_initialized() -> None:
         config.set_metrics_export_interval_ms(1000)
         config.set_tracing_export_interval_ms(1000)
 
+        import platform as platform_mod
+
         service_version = re.sub(r"[^a-zA-Z0-9._-]", ".", __version__)[:30]
+
+        from anaconda_cli_base.plugins import loaded_plugin_versions
+
+        plugin_versions_dict = {name: ver for name, ver in loaded_plugin_versions}
 
         attrs = ResourceAttributes(
             service_name="anaconda-cli-base",
             service_version=service_version,
-            environment="",
+            platform=f"{platform_mod.system().lower()}-{platform_mod.machine()}",
+            environment="production",
             anon_usage=cfg.share_session_identity,
         )
+        attrs.set_attributes(plugin_versions=plugin_versions_dict)
         initialize_telemetry(
             config=config,
             attributes=attrs,

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -54,16 +54,14 @@ def _ensure_initialized() -> None:
 
         cfg = TelemetryConfig()
 
-        api_key = None
-        try:
-            from anaconda_auth.config import AnacondaAuthConfig
-
-            api_key = AnacondaAuthConfig().api_key
-        except Exception:
-            pass
+        api_key = _get_api_key()
+        if api_key:
+            endpoint = cfg.endpoint
+        else:
+            endpoint = cfg.public_endpoint
 
         config = Configuration(
-            default_endpoint=cfg.endpoint,
+            default_endpoint=endpoint,
             default_auth_token=api_key,
         )
         if cfg.skip_internet_check:
@@ -86,6 +84,19 @@ def _ensure_initialized() -> None:
         _initialized = True
     except Exception:
         pass
+
+
+def _get_api_key():
+    try:
+        from anaconda_auth.exceptions import TokenNotFoundError
+        from anaconda_auth.token import TokenInfo
+
+        token_info = TokenInfo.load("anaconda.com")
+        return token_info.api_key
+    except TokenNotFoundError:
+        return None
+    except Exception:
+        return None
 
 
 def _before_command(args, prog_name) -> Optional[_CommandInfo]:

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -150,8 +150,8 @@ def _ensure_initialized() -> None:
             if config.proxy_url:
                 otel_config.set_proxy_url(config.proxy_url)
 
-            otel_config.set_metrics_export_interval_ms(1000)
-            otel_config.set_tracing_export_interval_ms(1000)
+            otel_config.set_metrics_export_interval_ms(config.export_interval_ms)
+            otel_config.set_tracing_export_interval_ms(config.export_interval_ms)
 
             import platform as platform_mod
 

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -50,6 +50,8 @@ def _ensure_initialized() -> None:
     if _initialized or not _is_enabled():
         return
     try:
+        os.environ.setdefault("GRPC_VERBOSITY", "NONE")
+
         from anaconda_opentelemetry.config import Configuration
         from anaconda_opentelemetry.attributes import ResourceAttributes
         from anaconda_opentelemetry.signals import initialize_telemetry
@@ -101,8 +103,9 @@ def _ensure_initialized() -> None:
         pass
     except Exception as exc:
         # SDK is installed but initialization failed (bad endpoint, auth,
-        # version mismatch, etc.). Log so misconfiguration is diagnosable.
-        logger.warning("Telemetry enabled but failed to initialize: %s", exc)
+        # version mismatch, etc.). Never surface to end users — telemetry
+        # must fail silently. Diagnosable only at DEBUG level.
+        logger.debug("Telemetry initialization failed: %s", exc)
 
 
 def _get_api_key() -> Optional[str]:

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -72,6 +72,32 @@ def _is_first_run() -> bool:
     return True
 
 
+def _detect_ai_agent() -> str:
+    indicators = {
+        "CURSOR_TRACE_ID": "cursor",
+        "CURSOR_SESSION_ID": "cursor",
+        "CLINE_TASK_ID": "cline",
+        "CONTINUE_GLOBAL_DIR": "continue",
+        "WINDSURF_SESSION_ID": "windsurf",
+        "OPENCODE": "opencode",
+    }
+    for env_var, agent in indicators.items():
+        if os.environ.get(env_var):
+            return agent
+    term_program = os.environ.get("TERM_PROGRAM", "")
+    if "cursor" in term_program.lower():
+        return "cursor"
+    if os.environ.get("CLAUDE_CODE"):
+        return "claude-code"
+    return ""
+
+
+def _detect_tty() -> bool:
+    import sys
+
+    return sys.stdout.isatty()
+
+
 @dataclass
 class _CommandInfo:
     command: str
@@ -151,6 +177,8 @@ def _ensure_initialized() -> None:
             ci_vendor=_detect_ci_vendor(),
             auth_state="authenticated" if api_key else "anonymous",
             is_first_run=_is_first_run(),
+            ai_agent=_detect_ai_agent(),
+            is_tty=_detect_tty(),
         )
         initialize_telemetry(
             config=config,
@@ -222,6 +250,8 @@ def _after_command(
             error_attrs: Dict[str, AttributeValue] = {
                 **attrs,
                 "error.type": type(error).__name__ if error else "unknown",
+                "error.code": str(getattr(error, "code", getattr(error, "errno", ""))),
+                "error.message": str(error)[:500] if error else "",
             }
             increment_counter("cli_command_errors", attributes=error_attrs)
     except Exception:

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -64,7 +64,9 @@ def _ensure_initialized() -> None:
         cfg = TelemetryConfig()
 
         api_key = _get_api_key()
-        if api_key:
+        if cfg.endpoint:
+            endpoint = cfg.endpoint
+        elif api_key:
             endpoint = AUTHENTICATED_ENDPOINT
         else:
             endpoint = PUBLIC_ENDPOINT

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -12,6 +12,7 @@ from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Any, Dict, Optional, Union
 
 logger = logging.getLogger(__name__)
@@ -22,6 +23,18 @@ _initialized = False
 _flush_timeout_ms = 500
 
 _suppress_http: ContextVar[bool] = ContextVar("_suppress_http", default=False)
+
+
+@lru_cache(maxsize=1)
+def _get_plugin_versions() -> Dict[str, str]:
+    from importlib.metadata import entry_points
+    from anaconda_cli_base import __version__
+
+    versions = {"anaconda-cli-base": __version__}
+    for ep in entry_points(group="anaconda_cli.subcommand"):
+        if ep.dist:
+            versions[ep.dist.name] = ep.dist.metadata["Version"]
+    return versions
 
 
 @dataclass
@@ -90,10 +103,6 @@ def _ensure_initialized() -> None:
 
         service_version = re.sub(r"[^a-zA-Z0-9._-]", ".", __version__)[:30]
 
-        from anaconda_cli_base.plugins import loaded_plugin_versions
-
-        plugin_versions_dict = {name: ver for name, ver in loaded_plugin_versions}
-
         attrs = ResourceAttributes(
             service_name="anaconda-cli-base",
             service_version=service_version,
@@ -101,7 +110,7 @@ def _ensure_initialized() -> None:
             environment="production",
             anon_usage=cfg.share_session_identity,
         )
-        attrs.set_attributes(plugin_versions=plugin_versions_dict)
+        attrs.set_attributes(plugin_versions=_get_plugin_versions())
         initialize_telemetry(
             config=config,
             attributes=attrs,

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -1,18 +1,8 @@
 """Centralized telemetry for the Anaconda CLI framework.
 
-Plugin authors use module-level functions with plugin_name:
-
-    from anaconda_cli_base.telemetry import count, histogram, traced, log_event
-
-    count("models_downloaded", plugin_name="ai")
-    histogram("download_size_bytes", plugin_name="ai", value=result.size)
-    log_event("download complete", event_name="model_downloaded", plugin_name="ai")
-
-    with traced("models_download", plugin_name="ai") as span:
-        ...
-
-All functions are no-ops when telemetry is disabled or anaconda-opentelemetry
-is not installed.
+All functions are safe to call regardless of whether telemetry is configured.
+When telemetry is disabled, every function is a no-op. Imports of the OTel SDK
+are deferred until the backend initializes.
 """
 
 import logging
@@ -40,13 +30,9 @@ AttributeValue = Union[str, bool, int, float, Sequence[Union[str, bool, int, flo
 config = TelemetryConfig()
 
 _lock = threading.Lock()
-_backend_initialized = False
+_initialized = False
+
 _suppress_http: ContextVar[bool] = ContextVar("_suppress_http", default=False)
-
-
-# ---------------------------------------------------------------------------
-# Environment detection helpers
-# ---------------------------------------------------------------------------
 
 
 @lru_cache(maxsize=1)
@@ -82,6 +68,20 @@ def _detect_ci_vendor() -> str:
     return ""
 
 
+def _is_first_run() -> bool:
+    from pathlib import Path
+
+    marker = Path.home() / ".anaconda" / ".telemetry_initialized"
+    if marker.exists():
+        return False
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+    except OSError:
+        pass
+    return True
+
+
 def _detect_ai_agent() -> str:
     indicators = {
         "CURSOR_TRACE_ID": "cursor",
@@ -106,53 +106,31 @@ def _detect_tty() -> bool:
     return sys.stdout.isatty()
 
 
-def _is_first_run() -> bool:
-    from pathlib import Path
-
-    marker = Path.home() / ".anaconda" / ".telemetry_initialized"
-    if marker.exists():
-        return False
-    try:
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.touch()
-    except OSError:
-        pass
-    return True
+@dataclass
+class _CommandInfo:
+    command: str
+    plugin: str
+    flags: str
+    start_time: float = field(default_factory=time.perf_counter)
 
 
-def _get_api_key() -> Optional[str]:
-    try:
-        from anaconda_auth.token import TokenInfo
-
-        token_info = TokenInfo.load("anaconda.com")
-        return token_info.api_key
-    except Exception:
-        return None
-
-
-# ---------------------------------------------------------------------------
-# Backend lifecycle
-# ---------------------------------------------------------------------------
-
-
-def _init_backend() -> None:
-    global _backend_initialized
-    if _backend_initialized:
+def _ensure_initialized() -> None:
+    global _initialized
+    if _initialized:
         return
     with _lock:
-        if _backend_initialized:
+        if _initialized:
             return
         if not config.enabled:
             return
         try:
             os.environ.setdefault("GRPC_VERBOSITY", "NONE")
 
-            import re
-            import platform as platform_mod
-
             from anaconda_opentelemetry.config import Configuration
             from anaconda_opentelemetry.attributes import ResourceAttributes
             from anaconda_opentelemetry.signals import initialize_telemetry
+
+            import re
 
             from anaconda_cli_base import __version__
 
@@ -174,6 +152,8 @@ def _init_backend() -> None:
 
             otel_config.set_metrics_export_interval_ms(1000)
             otel_config.set_tracing_export_interval_ms(1000)
+
+            import platform as platform_mod
 
             service_version = re.sub(r"[^a-zA-Z0-9._-]", ".", __version__)[:30]
 
@@ -197,178 +177,29 @@ def _init_backend() -> None:
                 attributes=attrs,
                 signal_types=["logging", "metrics", "tracing"],
             )
-            _backend_initialized = True
+            _initialized = True
         except ImportError:
             pass
         except Exception as exc:
             logger.debug("Telemetry initialization failed: %s", exc)
 
 
-def shutdown() -> None:
-    if not _backend_initialized:
-        return
+def _get_api_key() -> Optional[str]:
     try:
-        import atexit
+        from anaconda_auth.token import TokenInfo
 
-        from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.metrics import MeterProvider
-        from opentelemetry.sdk._logs import LoggerProvider
-        from opentelemetry import trace, metrics
-
-        from anaconda_opentelemetry.logging import _AnacondaLogger
-
-        flush_timeout = config.flush_timeout_ms
-
-        trace_provider = trace.get_tracer_provider()
-        if isinstance(trace_provider, TracerProvider):
-            trace_provider.force_flush(timeout_millis=flush_timeout)
-            if trace_provider._atexit_handler is not None:
-                atexit.unregister(trace_provider._atexit_handler)
-                trace_provider._atexit_handler = None
-
-        meter_provider = metrics.get_meter_provider()
-        if isinstance(meter_provider, MeterProvider):
-            meter_provider.force_flush(timeout_millis=flush_timeout)
-            if meter_provider._atexit_handler is not None:
-                atexit.unregister(meter_provider._atexit_handler)
-                meter_provider._atexit_handler = None
-
-        if _AnacondaLogger._instance is not None:
-            logger_provider = _AnacondaLogger._instance._provider
-            if isinstance(logger_provider, LoggerProvider):
-                logger_provider.force_flush(timeout_millis=flush_timeout)
-                if logger_provider._at_exit_handler is not None:
-                    atexit.unregister(logger_provider._at_exit_handler)
-                    logger_provider._at_exit_handler = None
+        token_info = TokenInfo.load("anaconda.com")
+        return token_info.api_key
     except Exception:
-        pass
-
-
-def is_enabled() -> bool:
-    return _backend_initialized
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
-
-@contextmanager
-def traced(
-    name: str, *, plugin_name: str, attributes: Optional[Dict[str, Any]] = None
-) -> Generator[Any, None, None]:
-    _init_backend()
-    if not _backend_initialized:
-        yield _NoOpSpan()
-        return
-    try:
-        from anaconda_opentelemetry import get_trace
-
-        with get_trace(name, attributes=_build_attrs(attributes, plugin_name)) as span:
-            yield span
-    except Exception:
-        yield _NoOpSpan()
-
-
-def count(
-    name: str,
-    *,
-    plugin_name: str,
-    value: int = 1,
-    attributes: Optional[Dict[str, Any]] = None,
-) -> None:
-    _init_backend()
-    if not _backend_initialized:
-        return
-    try:
-        from anaconda_opentelemetry import increment_counter
-
-        increment_counter(
-            name, by=value, attributes=_build_attrs(attributes, plugin_name)
-        )
-    except Exception:
-        pass
-
-
-def histogram(
-    name: str,
-    *,
-    plugin_name: str,
-    value: float,
-    attributes: Optional[Dict[str, Any]] = None,
-) -> None:
-    _init_backend()
-    if not _backend_initialized:
-        return
-    try:
-        from anaconda_opentelemetry import record_histogram
-
-        record_histogram(name, value, attributes=_build_attrs(attributes, plugin_name))
-    except Exception:
-        pass
-
-
-def log_event(
-    body: str,
-    *,
-    event_name: str,
-    plugin_name: str,
-    attributes: Optional[Dict[str, Any]] = None,
-) -> None:
-    _init_backend()
-    if not _backend_initialized:
-        return
-    try:
-        from anaconda_opentelemetry.signals import send_event
-
-        send_event(body, event_name, attributes=_build_attrs(attributes, plugin_name))
-    except Exception:
-        pass
-
-
-def get_otel_handler(level: int = logging.WARNING) -> logging.Handler:
-    _init_backend()
-    if not _backend_initialized:
-        return logging.NullHandler()
-    try:
-        from anaconda_opentelemetry.signals import get_telemetry_logger_handler
-
-        handler = get_telemetry_logger_handler()
-        if handler is None:
-            return logging.NullHandler()
-        handler.setLevel(level)
-        return handler
-    except Exception:
-        return logging.NullHandler()
-
-
-def _build_attrs(
-    attributes: Optional[Dict[str, Any]], plugin_name: str
-) -> Dict[str, Any]:
-    attrs = dict(attributes or {})
-    attrs["source"] = "anaconda-cli-base"
-    attrs["plugin"] = plugin_name
-    return attrs
-
-
-# ---------------------------------------------------------------------------
-# CLI framework internals
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class _CommandInfo:
-    command: str
-    plugin: str
-    flags: str
-    start_time: float = field(default_factory=time.perf_counter)
+        return None
 
 
 def _before_command(
     args: Optional[Sequence[str]], prog_name: Optional[str]
 ) -> Optional[_CommandInfo]:
-    _init_backend()
-    if not _backend_initialized:
+    """Start tracking a command. Returns None when telemetry is inactive."""
+    _ensure_initialized()
+    if not _initialized:
         return None
     command_name = " ".join(args[:2]) if args else prog_name or "unknown"
     plugin_name = args[0] if args else "root"
@@ -409,16 +240,186 @@ def _after_command(
     except Exception:
         pass
 
-    shutdown()
+    _shutdown_telemetry()
 
 
-# ---------------------------------------------------------------------------
-# HTTP span suppression
-# ---------------------------------------------------------------------------
+def _shutdown_telemetry() -> None:
+    """Flush all telemetry and disable atexit handlers to prevent exit hangs."""
+    if not _initialized:
+        return
+    try:
+        import atexit
+
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry import trace, metrics
+
+        from anaconda_opentelemetry.logging import _AnacondaLogger
+
+        flush_timeout = config.flush_timeout_ms
+
+        trace_provider = trace.get_tracer_provider()
+        if isinstance(trace_provider, TracerProvider):
+            trace_provider.force_flush(timeout_millis=flush_timeout)
+            if trace_provider._atexit_handler is not None:
+                atexit.unregister(trace_provider._atexit_handler)
+                trace_provider._atexit_handler = None
+
+        meter_provider = metrics.get_meter_provider()
+        if isinstance(meter_provider, MeterProvider):
+            meter_provider.force_flush(timeout_millis=flush_timeout)
+            if meter_provider._atexit_handler is not None:
+                atexit.unregister(meter_provider._atexit_handler)
+                meter_provider._atexit_handler = None
+
+        if _AnacondaLogger._instance is not None:
+            logger_provider = _AnacondaLogger._instance._provider
+            if isinstance(logger_provider, LoggerProvider):
+                logger_provider.force_flush(timeout_millis=flush_timeout)
+                if logger_provider._at_exit_handler is not None:
+                    atexit.unregister(logger_provider._at_exit_handler)
+                    logger_provider._at_exit_handler = None
+    except Exception:
+        pass
+
+
+def is_telemetry_enabled() -> bool:
+    return _initialized
+
+
+def get_otel_handler(level: int = logging.WARNING) -> logging.Handler:
+    """Get a logging handler that exports log records to the OTel backend.
+
+    Attach to any named logger to forward records at *level* or above to the
+    telemetry collector. The handler is additive — existing handlers (stderr,
+    file) continue to work normally.
+
+    Returns a NullHandler when telemetry is inactive or unavailable, so it is
+    always safe to call unconditionally.
+    """
+    _ensure_initialized()
+    if not _initialized:
+        return logging.NullHandler()
+    try:
+        from anaconda_opentelemetry.signals import get_telemetry_logger_handler
+
+        handler = get_telemetry_logger_handler()
+        if handler is None:
+            return logging.NullHandler()
+        handler.setLevel(level)
+        return handler
+    except Exception:
+        return logging.NullHandler()
+
+
+@contextmanager
+def traced(
+    name: str, plugin_name: str, attributes: Optional[Dict[str, Any]] = None
+) -> Generator[Any, None, None]:
+    """Create a child span for tracing a block of work.
+
+    Use to measure duration and capture events within a logical operation.
+    The span appears in trace views as a child of the CLI command's root span,
+    giving visibility into where time is spent.
+    """
+    _ensure_initialized()
+    if not _initialized:
+        yield _NoOpSpan()
+        return
+    try:
+        from anaconda_opentelemetry import get_trace
+
+        with get_trace(name, attributes=_build_attrs(attributes, plugin_name)) as span:
+            yield span
+    except Exception:
+        yield _NoOpSpan()
+
+
+def count(
+    name: str,
+    plugin_name: str,
+    value: int = 1,
+    attributes: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Increment a counter metric. Use for discrete occurrences you want to sum.
+
+    Counters are aggregated server-side (summed over time windows) and are ideal
+    for alerting on rates (e.g., errors/minute). Use instead of log_event when
+    you need numeric aggregation rather than individual event records.
+    """
+    _ensure_initialized()
+    if not _initialized:
+        return
+    try:
+        from anaconda_opentelemetry import increment_counter
+
+        increment_counter(
+            name, by=value, attributes=_build_attrs(attributes, plugin_name)
+        )
+    except Exception:
+        pass
+
+
+def histogram(
+    name: str,
+    plugin_name: str,
+    value: float,
+    attributes: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Record a distribution measurement. Use for values you want percentiles of.
+
+    Histograms compute p50/p95/p99 server-side, making them ideal for latency
+    and size measurements. Use instead of log_event when you need statistical
+    summaries rather than individual event records.
+    """
+    _ensure_initialized()
+    if not _initialized:
+        return
+    try:
+        from anaconda_opentelemetry import record_histogram
+
+        record_histogram(name, value, attributes=_build_attrs(attributes, plugin_name))
+    except Exception:
+        pass
+
+
+def log_event(
+    body: str,
+    event_name: str,
+    plugin_name: str,
+    attributes: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Send a structured log event. No-ops when telemetry is disabled."""
+    _ensure_initialized()
+    if not _initialized:
+        return
+    try:
+        from anaconda_opentelemetry.signals import send_event
+
+        send_event(body, event_name, attributes=_build_attrs(attributes, plugin_name))
+    except Exception:
+        pass
+
+
+def _build_attrs(
+    attributes: Optional[Dict[str, Any]], plugin_name: str
+) -> Dict[str, Any]:
+    attrs = dict(attributes or {})
+    attrs["source"] = "anaconda-cli-base"
+    attrs["plugin"] = plugin_name
+    return attrs
 
 
 @contextmanager
 def suppress_http_spans() -> Generator[None, None, None]:
+    """Suppress HTTP-level spans inside a block to reduce trace noise.
+
+    Use when polling or retrying produces many identical HTTP spans that
+    obscure the real operation. The parent span still records full duration,
+    and HTTP metrics (counters/histograms) are still emitted — only spans
+    are suppressed.
+    """
     token = _suppress_http.set(True)
     try:
         yield
@@ -428,11 +429,6 @@ def suppress_http_spans() -> Generator[None, None, None]:
 
 def is_http_suppressed() -> bool:
     return _suppress_http.get()
-
-
-# ---------------------------------------------------------------------------
-# NoOp span
-# ---------------------------------------------------------------------------
 
 
 class _NoOpSpan:

--- a/src/anaconda_cli_base/telemetry_config.py
+++ b/src/anaconda_cli_base/telemetry_config.py
@@ -16,3 +16,4 @@ class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
     enabled: bool = True
     share_session_identity: bool = True
     proxy_url: Optional[str] = None
+    flush_timeout_ms: int = 500

--- a/src/anaconda_cli_base/telemetry_config.py
+++ b/src/anaconda_cli_base/telemetry_config.py
@@ -1,6 +1,7 @@
-from typing import Optional
-
 from anaconda_cli_base.config import AnacondaBaseSettings
+
+DEFAULT_TELEMETRY_ENDPOINT = "https://metrics.aa.anaconda.com"
+PUBLIC_TELEMETRY_ENDPOINT = "https://public.telemetry.anaconda.com"
 
 
 class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
@@ -10,6 +11,7 @@ class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
     Environment variables use ANACONDA_TELEMETRY_ prefix.
     """
 
-    endpoint: Optional[str] = None
+    endpoint: str = DEFAULT_TELEMETRY_ENDPOINT
+    public_endpoint: str = PUBLIC_TELEMETRY_ENDPOINT
     anon_usage: bool = True
     skip_internet_check: bool = True

--- a/src/anaconda_cli_base/telemetry_config.py
+++ b/src/anaconda_cli_base/telemetry_config.py
@@ -1,4 +1,7 @@
-from typing import Optional
+import os
+from typing import Optional, Any
+
+from pydantic import field_validator, Field
 
 from anaconda_cli_base.config import AnacondaBaseSettings
 
@@ -13,8 +16,17 @@ class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
     Environment variables use ANACONDA_TELEMETRY_ prefix.
     """
 
-    enabled: bool = True
+    enabled: bool = Field(default=True, validate_default=True)
     endpoint: Optional[str] = None
     share_session_identity: bool = True
     proxy_url: Optional[str] = None
     flush_timeout_ms: int = 500
+
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def _check_disabled(cls, v: Any) -> Any:
+        if os.environ.get("OTEL_SDK_DISABLED", "").lower() in ("true", "1", "yes"):
+            # Checking for this env var ensures we don't load all the modules just
+            # to have them disabled anyway
+            return False
+        return v

--- a/src/anaconda_cli_base/telemetry_config.py
+++ b/src/anaconda_cli_base/telemetry_config.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from anaconda_cli_base.config import AnacondaBaseSettings
+
+
+class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
+    """Telemetry configuration.
+
+    Reads from [telemetry] in ~/.anaconda/config.toml.
+    Environment variables use ANACONDA_TELEMETRY_ prefix.
+    """
+
+    endpoint: Optional[str] = None
+    anon_usage: bool = True
+    skip_internet_check: bool = True

--- a/src/anaconda_cli_base/telemetry_config.py
+++ b/src/anaconda_cli_base/telemetry_config.py
@@ -14,6 +14,7 @@ class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
     """
 
     enabled: bool = True
+    endpoint: Optional[str] = None
     share_session_identity: bool = True
     proxy_url: Optional[str] = None
     flush_timeout_ms: int = 500

--- a/src/anaconda_cli_base/telemetry_config.py
+++ b/src/anaconda_cli_base/telemetry_config.py
@@ -21,6 +21,7 @@ class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
     share_session_identity: bool = True
     proxy_url: Optional[str] = None
     flush_timeout_ms: int = 500
+    export_interval_ms: int = 60000
 
     @field_validator("enabled", mode="before")
     @classmethod

--- a/src/anaconda_cli_base/telemetry_config.py
+++ b/src/anaconda_cli_base/telemetry_config.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from anaconda_cli_base.config import AnacondaBaseSettings
 
 AUTHENTICATED_ENDPOINT = "https://metrics.aa.anaconda.com"
@@ -13,4 +15,4 @@ class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
 
     enabled: bool = True
     share_session_identity: bool = True
-    skip_internet_check: bool = True
+    proxy_url: Optional[str] = None

--- a/src/anaconda_cli_base/telemetry_config.py
+++ b/src/anaconda_cli_base/telemetry_config.py
@@ -1,7 +1,7 @@
 from anaconda_cli_base.config import AnacondaBaseSettings
 
-DEFAULT_TELEMETRY_ENDPOINT = "https://metrics.aa.anaconda.com"
-PUBLIC_TELEMETRY_ENDPOINT = "https://public.telemetry.anaconda.com"
+AUTHENTICATED_ENDPOINT = "https://metrics.aa.anaconda.com"
+PUBLIC_ENDPOINT = "https://public.telemetry.anaconda.com"
 
 
 class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
@@ -11,7 +11,6 @@ class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
     Environment variables use ANACONDA_TELEMETRY_ prefix.
     """
 
-    endpoint: str = DEFAULT_TELEMETRY_ENDPOINT
-    public_endpoint: str = PUBLIC_TELEMETRY_ENDPOINT
-    anon_usage: bool = True
+    enabled: bool = True
+    share_session_identity: bool = True
     skip_internet_check: bool = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ from click.testing import Result
 # Force usage of new CLI
 os.environ["ANACONDA_CLI_FORCE_NEW"] = "true"
 os.environ["ANACONDA_CLI_DISABLE_PLUGINS"] = "true"
+os.environ["OTEL_SDK_DISABLED"] = "true"
 
 import anaconda_cli_base.cli
 
@@ -60,11 +61,6 @@ def disable_dot_env(mocker: MockerFixture) -> None:
 @pytest.fixture(autouse=True)
 def disable_config_toml(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(tmp_path / "empty-config.toml"))
-
-
-@pytest.fixture(autouse=True)
-def disable_telemetry(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,11 @@ def disable_config_toml(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(tmp_path / "empty-config.toml"))
 
 
+@pytest.fixture(autouse=True)
+def disable_telemetry(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+
+
 @pytest.fixture()
 def tmp_cwd(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
     """Create & return a temporary directory after setting current working directory to it."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -358,6 +358,55 @@ def test_root_level_table(config_toml: Path) -> None:
     assert config.foo == "baz"
 
 
+def test_table_name_reads_top_level_section(config_toml: Path) -> None:
+    class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
+        endpoint: Optional[str] = None
+        anon_usage: bool = True
+
+    config_toml.write_text(
+        dedent("""\
+            [telemetry]
+            endpoint = "https://otel.anaconda.com:4317"
+            anon_usage = false
+        """)
+    )
+
+    config = TelemetryConfig()
+    assert config.endpoint == "https://otel.anaconda.com:4317"
+    assert config.anon_usage is False
+
+
+def test_table_name_env_prefix(monkeypatch: MonkeyPatch, config_toml: Path) -> None:
+    class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
+        endpoint: Optional[str] = None
+
+    monkeypatch.setenv("ANACONDA_TELEMETRY_ENDPOINT", "https://env-override.com:4317")
+
+    config = TelemetryConfig()
+    assert config.endpoint == "https://env-override.com:4317"
+
+
+def test_table_name_write_config(config_toml: Path) -> None:
+    class TelemetryConfig(AnacondaBaseSettings, table_name="telemetry"):
+        endpoint: Optional[str] = None
+        anon_usage: bool = True
+
+    config = TelemetryConfig(endpoint="https://otel.anaconda.com:4317")
+    config.write_config()
+
+    contents = config_toml.read_text()
+    assert "[telemetry]" in contents
+    assert 'endpoint = "https://otel.anaconda.com:4317"' in contents
+    assert "[plugin" not in contents
+
+
+def test_table_name_and_plugin_name_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="Cannot specify both"):
+
+        class BadConfig(AnacondaBaseSettings, plugin_name="foo", table_name="bar"):
+            field: str = "value"
+
+
 class NestedFlag(BaseModel):
     flag: bool = True
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -85,6 +85,8 @@ def test_successful_command_records_metrics(mock_otel: dict) -> None:
             "command": "ai chat",
             "plugin": "ai",
             "source": "anaconda-cli-base",
+            "flags": "",
+            "exit_code": 0,
         },
     )
 
@@ -104,6 +106,8 @@ def test_failed_command_records_error_metric(mock_otel: dict) -> None:
             "command": "ai chat",
             "plugin": "ai",
             "source": "anaconda-cli-base",
+            "flags": "",
+            "exit_code": 0,
         },
     )
     assert calls[1] == call(
@@ -112,6 +116,8 @@ def test_failed_command_records_error_metric(mock_otel: dict) -> None:
             "command": "ai chat",
             "plugin": "ai",
             "source": "anaconda-cli-base",
+            "flags": "",
+            "exit_code": 0,
             "error.type": "RuntimeError",
         },
     )

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from textwrap import dedent
-from typing import Generator, Iterator
+from typing import Any, Generator, Iterator
 from unittest.mock import call
 
 import pytest
@@ -382,7 +382,7 @@ def test_traced_passes_correct_attributes(
     monkeypatch.setattr(mod, "_initialized", True)
 
     @contextmanager
-    def fake_get_trace(name, attributes=None):
+    def fake_get_trace(name: str, attributes: Any = None) -> Generator[Any, None, None]:
         yield mocker.MagicMock()
 
     get_trace = mocker.patch(

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -9,6 +9,8 @@ import pytest
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 
+from .conftest import CLIInvoker
+
 
 @pytest.fixture(autouse=True)
 def isolate_telemetry(monkeypatch: MonkeyPatch) -> Generator[None, None, None]:
@@ -175,3 +177,83 @@ def test_noop_span_methods_are_safe() -> None:
     span.add_exception(RuntimeError("boom"))
     span.set_error_status("error")
     span.add_attributes({"key": "value"})
+
+
+def test_cli_success_calls_telemetry(
+    invoke_cli: CLIInvoker, mocker: MockerFixture
+) -> None:
+    before = mocker.patch("anaconda_cli_base.cli._before_command")
+    after = mocker.patch("anaconda_cli_base.cli._after_command")
+
+    result = invoke_cli(["some-test-subcommand"])
+    assert result.exit_code == 0
+
+    before.assert_called_once()
+    after.assert_called_once()
+    _, kwargs = after.call_args
+    assert kwargs["success"] is True
+
+
+def test_cli_failure_calls_telemetry_with_error(
+    invoke_cli: CLIInvoker, mocker: MockerFixture
+) -> None:
+    from anaconda_cli_base.exceptions import register_error_handler
+
+    class _TelTestError(Exception):
+        pass
+
+    @register_error_handler(_TelTestError)
+    def _handle(e: type) -> int:
+        return 99
+
+    import anaconda_cli_base.cli
+
+    @anaconda_cli_base.cli.app.command("tel-fail")
+    def tel_fail() -> None:
+        raise _TelTestError("boom")
+
+    before = mocker.patch("anaconda_cli_base.cli._before_command")
+    after = mocker.patch("anaconda_cli_base.cli._after_command")
+
+    result = invoke_cli(["tel-fail"])
+    assert result.exit_code == 99
+
+    before.assert_called_once()
+    after.assert_called_once()
+    _, kwargs = after.call_args
+    assert kwargs["success"] is False
+    assert isinstance(kwargs["error"], _TelTestError)
+
+
+def test_cli_retry_calls_telemetry_once(
+    invoke_cli: CLIInvoker, mocker: MockerFixture
+) -> None:
+    from anaconda_cli_base.exceptions import register_error_handler
+
+    class _TelRetryError(Exception):
+        pass
+
+    call_count = 0
+
+    @register_error_handler(_TelRetryError)
+    def _handle(e: type) -> int:
+        return -1
+
+    import anaconda_cli_base.cli
+
+    @anaconda_cli_base.cli.app.command("tel-retry")
+    def tel_retry() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 2:
+            raise _TelRetryError("retry me")
+
+    before = mocker.patch("anaconda_cli_base.cli._before_command")
+    after = mocker.patch("anaconda_cli_base.cli._after_command")
+
+    result = invoke_cli(["tel-retry"])
+    assert result.exit_code == 0
+    assert call_count == 2
+
+    before.assert_called_once()
+    after.assert_called_once()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -12,6 +12,9 @@ from pytest_mock import MockerFixture
 from .conftest import CLIInvoker
 
 
+from anaconda_cli_base.telemetry_config import TelemetryConfig
+
+
 @pytest.fixture(autouse=True)
 def isolate_telemetry(monkeypatch: MonkeyPatch) -> Generator[None, None, None]:
     import anaconda_cli_base.telemetry as mod
@@ -61,6 +64,14 @@ def mock_otel(mocker: MockerFixture) -> dict:
         "record_histogram": hist,
         "shutdown": shutdown,
     }
+
+
+@pytest.mark.parametrize("value", ["TRUE", "1", "YES"])
+@pytest.mark.usefixtures("config_toml")
+def test_telemetry_disabled(monkeypatch: MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("OTEL_SDK_DISABLED", value)
+    config = TelemetryConfig()
+    assert not config.enabled
 
 
 def test_successful_command_records_metrics(mock_otel: dict) -> None:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -119,6 +119,8 @@ def test_failed_command_records_error_metric(mock_otel: dict) -> None:
             "flags": "",
             "exit_code": 0,
             "error.type": "RuntimeError",
+            "error.code": "",
+            "error.message": "connection timeout",
         },
     )
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -56,7 +56,7 @@ class TestInit:
 
         results = []
 
-        def call_init():
+        def call_init() -> None:
             _ensure_initialized()
             results.append(mod._initialized)
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -257,3 +257,171 @@ def test_cli_retry_calls_telemetry_once(
 
     before.assert_called_once()
     after.assert_called_once()
+
+
+def test_count_calls_increment_counter_with_source(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch
+) -> None:
+    import anaconda_cli_base.telemetry as mod
+
+    monkeypatch.setattr(mod, "_initialized", True)
+    inc = mocker.patch("anaconda_opentelemetry.increment_counter", return_value=True)
+
+    from anaconda_cli_base.telemetry import count
+
+    count("models_downloaded", plugin_name="ai", attributes={"model": "llama3"})
+
+    inc.assert_called_once_with(
+        "models_downloaded",
+        by=1,
+        attributes={"model": "llama3", "source": "anaconda-cli-base", "plugin": "ai"},
+    )
+
+
+def test_count_noop_when_disabled(mocker: MockerFixture) -> None:
+    inc = mocker.patch("anaconda_opentelemetry.increment_counter")
+
+    from anaconda_cli_base.telemetry import count
+
+    count("anything", plugin_name="test-plugin")
+
+    inc.assert_not_called()
+
+
+def test_histogram_calls_record_histogram_with_source_and_plugin(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch
+) -> None:
+    import anaconda_cli_base.telemetry as mod
+
+    monkeypatch.setattr(mod, "_initialized", True)
+    hist = mocker.patch("anaconda_opentelemetry.record_histogram", return_value=True)
+
+    from anaconda_cli_base.telemetry import histogram
+
+    histogram(
+        "download_size_bytes",
+        plugin_name="ai",
+        value=1024.5,
+        attributes={"model": "llama3"},
+    )
+
+    hist.assert_called_once_with(
+        "download_size_bytes",
+        1024.5,
+        attributes={"model": "llama3", "source": "anaconda-cli-base", "plugin": "ai"},
+    )
+
+
+def test_histogram_noop_when_disabled(mocker: MockerFixture) -> None:
+    hist = mocker.patch("anaconda_opentelemetry.record_histogram")
+
+    from anaconda_cli_base.telemetry import histogram
+
+    histogram("anything", plugin_name="test-plugin", value=1.0)
+
+    hist.assert_not_called()
+
+
+def test_log_event_calls_send_event_with_source_and_plugin(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch
+) -> None:
+    import anaconda_cli_base.telemetry as mod
+
+    monkeypatch.setattr(mod, "_initialized", True)
+    send = mocker.patch("anaconda_opentelemetry.signals.send_event", return_value=True)
+
+    from anaconda_cli_base.telemetry import log_event
+
+    log_event(
+        "user started chat",
+        "chat_started",
+        plugin_name="ai",
+        attributes={"mode": "stream"},
+    )
+
+    send.assert_called_once_with(
+        "user started chat",
+        "chat_started",
+        attributes={"mode": "stream", "source": "anaconda-cli-base", "plugin": "ai"},
+    )
+
+
+def test_log_event_noop_when_disabled(mocker: MockerFixture) -> None:
+    send = mocker.patch("anaconda_opentelemetry.signals.send_event")
+
+    from anaconda_cli_base.telemetry import log_event
+
+    log_event("anything", "event", plugin_name="test-plugin")
+
+    send.assert_not_called()
+
+
+def test_traced_yields_noop_span_when_disabled() -> None:
+    from anaconda_cli_base.telemetry import traced, _NoOpSpan
+
+    with traced("some_operation", plugin_name="ai") as span:
+        assert isinstance(span, _NoOpSpan)
+
+
+def test_traced_passes_correct_attributes(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch
+) -> None:
+    import anaconda_cli_base.telemetry as mod
+    from contextlib import contextmanager
+
+    monkeypatch.setattr(mod, "_initialized", True)
+
+    @contextmanager
+    def fake_get_trace(name, attributes=None):
+        yield mocker.MagicMock()
+
+    get_trace = mocker.patch(
+        "anaconda_opentelemetry.get_trace", side_effect=fake_get_trace
+    )
+
+    from anaconda_cli_base.telemetry import traced
+
+    with traced("models_download", plugin_name="ai", attributes={"model": "llama3"}):
+        pass
+
+    get_trace.assert_called_once_with(
+        "models_download",
+        attributes={"model": "llama3", "source": "anaconda-cli-base", "plugin": "ai"},
+    )
+
+
+def test_traced_yields_noop_on_exception(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch
+) -> None:
+    import anaconda_cli_base.telemetry as mod
+
+    monkeypatch.setattr(mod, "_initialized", True)
+    mocker.patch("anaconda_opentelemetry.get_trace", side_effect=RuntimeError("broken"))
+
+    from anaconda_cli_base.telemetry import traced, _NoOpSpan
+
+    with traced("will_fail", plugin_name="test-plugin") as span:
+        assert isinstance(span, _NoOpSpan)
+
+
+def test_suppress_http_spans_sets_and_resets() -> None:
+    from anaconda_cli_base.telemetry import suppress_http_spans, is_http_suppressed
+
+    assert is_http_suppressed() is False
+
+    with suppress_http_spans():
+        assert is_http_suppressed() is True
+
+    assert is_http_suppressed() is False
+
+
+def test_suppress_http_spans_nests_correctly() -> None:
+    from anaconda_cli_base.telemetry import suppress_http_spans, is_http_suppressed
+
+    with suppress_http_spans():
+        assert is_http_suppressed() is True
+        with suppress_http_spans():
+            assert is_http_suppressed() is True
+        assert is_http_suppressed() is True
+
+    assert is_http_suppressed() is False

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -4,7 +4,7 @@ NOTE: The test conftest.py sets OTEL_SDK_DISABLED=true, which means
 config.enabled is always False in this test session. The real OTel backend
 never initializes during unit tests.
 
-Tests that need to verify "enabled" behavior set _backend_initialized=True
+Tests that need to verify "enabled" behavior set _initialized=True
 directly via monkeypatch to simulate an initialized backend without actually
 running the OTel SDK.
 
@@ -26,25 +26,25 @@ from pytest_mock import MockerFixture
 def reset_backend(monkeypatch: MonkeyPatch) -> Generator[None, None, None]:
     import anaconda_cli_base.telemetry as mod
 
-    monkeypatch.setattr(mod, "_backend_initialized", False)
+    monkeypatch.setattr(mod, "_initialized", False)
     yield
 
 
 class TestInit:
     def test_init_backend_respects_disabled_config(self) -> None:
         import anaconda_cli_base.telemetry as mod
-        from anaconda_cli_base.telemetry import _init_backend, config
+        from anaconda_cli_base.telemetry import _ensure_initialized, config
 
         assert config.enabled is False
-        _init_backend()
-        assert mod._backend_initialized is False
+        _ensure_initialized()
+        assert mod._initialized is False
 
     def test_init_backend_called_by_public_functions(
         self, mocker: MockerFixture
     ) -> None:
         import anaconda_cli_base.telemetry as mod
 
-        mock_init = mocker.patch.object(mod, "_init_backend")
+        mock_init = mocker.patch.object(mod, "_ensure_initialized")
         from anaconda_cli_base.telemetry import count
 
         count("x", plugin_name="test")
@@ -52,13 +52,13 @@ class TestInit:
 
     def test_thread_safety(self) -> None:
         import anaconda_cli_base.telemetry as mod
-        from anaconda_cli_base.telemetry import _init_backend
+        from anaconda_cli_base.telemetry import _ensure_initialized
 
         results = []
 
         def call_init():
-            _init_backend()
-            results.append(mod._backend_initialized)
+            _ensure_initialized()
+            results.append(mod._initialized)
 
         threads = [threading.Thread(target=call_init) for _ in range(10)]
         for t in threads:
@@ -71,8 +71,10 @@ class TestInit:
 
 class TestNoOpWhenDisabled:
     def test_count_noop(self) -> None:
+        import anaconda_cli_base.telemetry as mod
         from anaconda_cli_base.telemetry import count
 
+        assert not mod._initialized
         count("metric", plugin_name="test")
 
     def test_histogram_noop(self) -> None:
@@ -130,7 +132,7 @@ class TestCommandTracking:
         import anaconda_cli_base.telemetry as mod
         from anaconda_cli_base.telemetry import _before_command
 
-        assert not mod._backend_initialized
+        assert not mod._initialized
         result = _before_command(["ai", "chat"], "anaconda")
         assert result is None
 
@@ -140,7 +142,7 @@ class TestCommandTracking:
         import anaconda_cli_base.telemetry as mod
         from anaconda_cli_base.telemetry import _before_command
 
-        monkeypatch.setattr(mod, "_backend_initialized", True)
+        monkeypatch.setattr(mod, "_initialized", True)
         info = _before_command(
             ["ai", "chat", "--verbose", "--model=llama3"], "anaconda"
         )
@@ -153,7 +155,7 @@ class TestCommandTracking:
         import anaconda_cli_base.telemetry as mod
         from anaconda_cli_base.telemetry import _before_command
 
-        monkeypatch.setattr(mod, "_backend_initialized", True)
+        monkeypatch.setattr(mod, "_initialized", True)
         info = _before_command([], "anaconda")
         assert info is not None
         assert info.command == "anaconda"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -32,8 +32,7 @@ def telemetry_enabled(monkeypatch: MonkeyPatch, config_toml: Path) -> None:
     config_toml.write_text(
         dedent("""\
             [telemetry]
-            endpoint = "http://localhost:19999"
-            public_endpoint = "http://localhost:19999"
+            enabled = true
             skip_internet_check = true
         """)
     )
@@ -117,10 +116,21 @@ def test_failed_command_records_error_metric(mock_otel: dict) -> None:
     )
 
 
-def test_telemetry_disabled_when_endpoint_blanked(
+def test_telemetry_disabled_via_config(
     monkeypatch: MonkeyPatch, config_toml: Path
 ) -> None:
-    config_toml.write_text('[telemetry]\nendpoint = ""\n')
+    config_toml.write_text("[telemetry]\nenabled = false\n")
+
+    from anaconda_cli_base.telemetry import _is_enabled
+
+    assert _is_enabled() is False
+
+
+def test_telemetry_disabled_via_env_var(
+    monkeypatch: MonkeyPatch, config_toml: Path
+) -> None:
+    config_toml.write_text("[telemetry]\n")
+    monkeypatch.setenv("ANACONDA_TELEMETRY_ENABLED", "false")
 
     from anaconda_cli_base.telemetry import _is_enabled
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,525 +1,241 @@
+"""Unit tests for telemetry module.
+
+NOTE: The test conftest.py sets OTEL_SDK_DISABLED=true, which means
+config.enabled is always False in this test session. The real OTel backend
+never initializes during unit tests.
+
+Tests that need to verify "enabled" behavior set _backend_initialized=True
+directly via monkeypatch to simulate an initialized backend without actually
+running the OTel SDK.
+
+Integration tests (test_telemetry_integration.py) run in a separate pytest
+invocation with telemetry fully enabled against a local oteltest receiver.
+"""
+
 from __future__ import annotations
 
-from pathlib import Path
-from textwrap import dedent
-from typing import Any, Generator, Iterator
-from unittest.mock import call
+import threading
+from typing import Generator
 
 import pytest
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 
-from .conftest import CLIInvoker
-
-
-from anaconda_cli_base.telemetry_config import TelemetryConfig
-
 
 @pytest.fixture(autouse=True)
-def isolate_telemetry(monkeypatch: MonkeyPatch) -> Generator[None, None, None]:
+def reset_backend(monkeypatch: MonkeyPatch) -> Generator[None, None, None]:
     import anaconda_cli_base.telemetry as mod
 
-    monkeypatch.setattr(mod, "_initialized", False)
-    monkeypatch.setattr(mod, "_get_plugin_versions", lambda: {})
+    monkeypatch.setattr(mod, "_backend_initialized", False)
     yield
 
 
-@pytest.fixture
-def config_toml(tmp_path: Path, monkeypatch: MonkeyPatch) -> Iterator[Path]:
-    config_file = tmp_path / "config.toml"
-    monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_file))
-    yield config_file
+class TestInit:
+    def test_init_backend_respects_disabled_config(self) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import _init_backend, config
+
+        assert config.enabled is False
+        _init_backend()
+        assert mod._backend_initialized is False
+
+    def test_init_backend_called_by_public_functions(
+        self, mocker: MockerFixture
+    ) -> None:
+        import anaconda_cli_base.telemetry as mod
+
+        mock_init = mocker.patch.object(mod, "_init_backend")
+        from anaconda_cli_base.telemetry import count
+
+        count("x", plugin_name="test")
+        mock_init.assert_called_once()
+
+    def test_thread_safety(self) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import _init_backend
+
+        results = []
+
+        def call_init():
+            _init_backend()
+            results.append(mod._backend_initialized)
+
+        threads = [threading.Thread(target=call_init) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 10
 
 
-@pytest.fixture
-def telemetry_enabled(monkeypatch: MonkeyPatch, config_toml: Path) -> None:
-    config_toml.write_text(
-        dedent("""\
-            [telemetry]
-            enabled = true
-            skip_internet_check = true
-        """)
-    )
+class TestNoOpWhenDisabled:
+    def test_count_noop(self) -> None:
+        from anaconda_cli_base.telemetry import count
+
+        count("metric", plugin_name="test")
+
+    def test_histogram_noop(self) -> None:
+        from anaconda_cli_base.telemetry import histogram
+
+        histogram("metric", plugin_name="test", value=1.0)
+
+    def test_log_event_noop(self) -> None:
+        from anaconda_cli_base.telemetry import log_event
+
+        log_event("body", event_name="name", plugin_name="test")
+
+    def test_traced_yields_noop_span(self) -> None:
+        from anaconda_cli_base.telemetry import traced, _NoOpSpan
+
+        with traced("operation", plugin_name="test") as span:
+            assert isinstance(span, _NoOpSpan)
+
+    def test_get_otel_handler_returns_null_handler(self) -> None:
+        import logging
+        from anaconda_cli_base.telemetry import get_otel_handler
+
+        handler = get_otel_handler()
+        assert isinstance(handler, logging.NullHandler)
 
 
-@pytest.fixture
-def mock_otel(mocker: MockerFixture) -> dict:
-    """Stub the OTel initialization and recording functions.
+class TestAttrs:
+    def test_build_attrs_includes_source_and_plugin(self) -> None:
+        from anaconda_cli_base.telemetry import _build_attrs
 
-    Replaces _ensure_initialized with a simple flag-set so tests exercise
-    _before_command/_after_command logic without requiring anaconda-opentelemetry.
-    """
-    import anaconda_cli_base.telemetry as mod
-
-    mocker.patch(
-        "anaconda_cli_base.telemetry._ensure_initialized",
-        side_effect=lambda: setattr(mod, "_initialized", True),
-    )
-    inc = mocker.patch("anaconda_opentelemetry.increment_counter", return_value=True)
-    hist = mocker.patch("anaconda_opentelemetry.record_histogram", return_value=True)
-    shutdown = mocker.patch("anaconda_cli_base.telemetry._shutdown_telemetry")
-
-    return {
-        "increment_counter": inc,
-        "record_histogram": hist,
-        "shutdown": shutdown,
-    }
-
-
-@pytest.mark.parametrize("value", ["TRUE", "1", "YES"])
-@pytest.mark.usefixtures("config_toml")
-def test_telemetry_disabled(monkeypatch: MonkeyPatch, value: str) -> None:
-    monkeypatch.setenv("OTEL_SDK_DISABLED", value)
-    config = TelemetryConfig()
-    assert not config.enabled
-
-
-def test_successful_command_records_metrics(mock_otel: dict) -> None:
-    from anaconda_cli_base.telemetry import _before_command, _after_command
-
-    info = _before_command(["ai", "chat"], "anaconda")
-    assert info is not None
-    assert info.command == "ai chat"
-    assert info.plugin == "ai"
-
-    _after_command(info, success=True)
-
-    mock_otel["record_histogram"].assert_called_once()
-    hist_args = mock_otel["record_histogram"].call_args
-    assert hist_args[0][0] == "cli_command_duration_ms"
-    assert hist_args[0][2]["command"] == "ai chat"
-    assert hist_args[0][2]["source"] == "anaconda-cli-base"
-
-    mock_otel["increment_counter"].assert_called_once_with(
-        "cli_command_invoked",
-        attributes={
-            "command": "ai chat",
-            "plugin": "ai",
+        result = _build_attrs({"key": "value"}, "my-plugin")
+        assert result == {
+            "key": "value",
             "source": "anaconda-cli-base",
-            "flags": "",
-            "exit_code": 0,
-        },
-    )
+            "plugin": "my-plugin",
+        }
 
+    def test_build_attrs_handles_none(self) -> None:
+        from anaconda_cli_base.telemetry import _build_attrs
+
+        result = _build_attrs(None, "test")
+        assert result == {"source": "anaconda-cli-base", "plugin": "test"}
+
+    def test_build_attrs_does_not_mutate_input(self) -> None:
+        from anaconda_cli_base.telemetry import _build_attrs
+
+        original = {"key": "value"}
+        result = _build_attrs(original, "test")
+        assert "source" not in original
+        assert "source" in result
 
-def test_failed_command_records_error_metric(mock_otel: dict) -> None:
-    from anaconda_cli_base.telemetry import _before_command, _after_command
 
-    info = _before_command(["ai", "chat"], "anaconda")
-    _after_command(info, success=False, error=RuntimeError("connection timeout"))
+class TestCommandTracking:
+    def test_before_command_returns_none_when_disabled(self) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import _before_command
 
-    calls = mock_otel["increment_counter"].call_args_list
-    assert len(calls) == 2
+        assert not mod._backend_initialized
+        result = _before_command(["ai", "chat"], "anaconda")
+        assert result is None
 
-    assert calls[0] == call(
-        "cli_command_invoked",
-        attributes={
-            "command": "ai chat",
-            "plugin": "ai",
-            "source": "anaconda-cli-base",
-            "flags": "",
-            "exit_code": 0,
-        },
-    )
-    assert calls[1] == call(
-        "cli_command_errors",
-        attributes={
-            "command": "ai chat",
-            "plugin": "ai",
-            "source": "anaconda-cli-base",
-            "flags": "",
-            "exit_code": 0,
-            "error.type": "RuntimeError",
-            "error.code": "",
-            "error.message": "connection timeout",
-        },
-    )
+    def test_before_command_extracts_command_info(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import _before_command
 
+        monkeypatch.setattr(mod, "_backend_initialized", True)
+        info = _before_command(
+            ["ai", "chat", "--verbose", "--model=llama3"], "anaconda"
+        )
+        assert info is not None
+        assert info.command == "ai chat"
+        assert info.plugin == "ai"
+        assert info.flags == "--verbose,--model"
 
-def test_telemetry_disabled_via_config(
-    monkeypatch: MonkeyPatch, config_toml: Path
-) -> None:
-    config_toml.write_text("[telemetry]\nenabled = false\n")
+    def test_before_command_handles_empty_args(self, monkeypatch: MonkeyPatch) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import _before_command
 
-    from anaconda_cli_base.telemetry import _is_enabled
+        monkeypatch.setattr(mod, "_backend_initialized", True)
+        info = _before_command([], "anaconda")
+        assert info is not None
+        assert info.command == "anaconda"
+        assert info.plugin == "root"
+        assert info.flags == ""
 
-    assert _is_enabled() is False
+    def test_after_command_noop_when_info_is_none(self) -> None:
+        from anaconda_cli_base.telemetry import _after_command
 
+        _after_command(None, success=True)
 
-def test_telemetry_disabled_via_env_var(
-    monkeypatch: MonkeyPatch, config_toml: Path
-) -> None:
-    config_toml.write_text("[telemetry]\n")
-    monkeypatch.setenv("ANACONDA_TELEMETRY_ENABLED", "false")
 
-    from anaconda_cli_base.telemetry import _is_enabled
+class TestDetection:
+    def test_detect_ci_vendor_github(self, monkeypatch: MonkeyPatch) -> None:
+        from anaconda_cli_base.telemetry import _detect_ci_vendor
 
-    assert _is_enabled() is False
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        assert _detect_ci_vendor() == "github-actions"
 
+    def test_detect_ci_vendor_unknown(self, monkeypatch: MonkeyPatch) -> None:
+        from anaconda_cli_base.telemetry import _detect_ci_vendor
 
-def test_telemetry_disabled_by_otel_sdk_disabled(
-    monkeypatch: MonkeyPatch, telemetry_enabled: None
-) -> None:
-    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        monkeypatch.setenv("CI", "true")
+        assert _detect_ci_vendor() == "unknown-ci"
 
-    from anaconda_cli_base.telemetry import _before_command
+    def test_detect_ci_vendor_none(self, monkeypatch: MonkeyPatch) -> None:
+        from anaconda_cli_base.telemetry import _detect_ci_vendor
 
-    info = _before_command(["ai", "chat"], "anaconda")
-    assert info is None
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        assert _detect_ci_vendor() == ""
 
+    def test_detect_ai_agent_opencode(self, monkeypatch: MonkeyPatch) -> None:
+        from anaconda_cli_base.telemetry import _detect_ai_agent
 
-def test_after_command_noop_when_info_is_none(mock_otel: dict) -> None:
-    from anaconda_cli_base.telemetry import _after_command
+        monkeypatch.setenv("OPENCODE", "1")
+        assert _detect_ai_agent() == "opencode"
 
-    _after_command(None, success=True)
+    def test_detect_ai_agent_cursor(self, monkeypatch: MonkeyPatch) -> None:
+        from anaconda_cli_base.telemetry import _detect_ai_agent
 
-    mock_otel["increment_counter"].assert_not_called()
-    mock_otel["record_histogram"].assert_not_called()
+        monkeypatch.delenv("OPENCODE", raising=False)
+        monkeypatch.setenv("TERM_PROGRAM", "Cursor")
+        assert _detect_ai_agent() == "cursor"
 
+    def test_detect_ai_agent_none(self, monkeypatch: MonkeyPatch) -> None:
+        from anaconda_cli_base.telemetry import _detect_ai_agent
 
-def test_shutdown_called_after_command(mock_otel: dict) -> None:
-    from anaconda_cli_base.telemetry import _before_command, _after_command
+        for var in [
+            "OPENCODE",
+            "CURSOR_TRACE_ID",
+            "CURSOR_SESSION_ID",
+            "CLINE_TASK_ID",
+            "CONTINUE_GLOBAL_DIR",
+            "WINDSURF_SESSION_ID",
+            "CLAUDE_CODE",
+        ]:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("TERM_PROGRAM", "iTerm2")
+        assert _detect_ai_agent() == ""
 
-    info = _before_command(["ai", "chat"], "anaconda")
-    _after_command(info, success=True)
+    def test_detect_tty(self) -> None:
+        from anaconda_cli_base.telemetry import _detect_tty
 
-    mock_otel["shutdown"].assert_called_once()
+        assert _detect_tty() is False
 
 
-def test_duration_is_positive(mock_otel: dict) -> None:
-    from anaconda_cli_base.telemetry import _before_command, _after_command
-    import time
+class TestHttpSuppression:
+    def test_suppress_http_spans(self) -> None:
+        from anaconda_cli_base.telemetry import suppress_http_spans, is_http_suppressed
 
-    info = _before_command(["ai", "chat"], "anaconda")
-    time.sleep(0.01)
-    _after_command(info, success=True)
-
-    hist_args = mock_otel["record_histogram"].call_args
-    duration_ms = hist_args[0][1]
-    assert duration_ms >= 10.0
-
-
-def test_noop_span_methods_are_safe() -> None:
-    from anaconda_cli_base.telemetry import _NoOpSpan
-
-    span = _NoOpSpan()
-    span.add_event("test", {"key": "value"})
-    span.add_exception(RuntimeError("boom"))
-    span.set_error_status("error")
-    span.add_attributes({"key": "value"})
-
-
-def test_cli_success_calls_telemetry(
-    invoke_cli: CLIInvoker, mocker: MockerFixture
-) -> None:
-    before = mocker.patch("anaconda_cli_base.cli._before_command")
-    after = mocker.patch("anaconda_cli_base.cli._after_command")
-
-    result = invoke_cli(["some-test-subcommand"])
-    assert result.exit_code == 0
-
-    before.assert_called_once()
-    after.assert_called_once()
-    _, kwargs = after.call_args
-    assert kwargs["success"] is True
-
-
-def test_cli_failure_calls_telemetry_with_error(
-    invoke_cli: CLIInvoker, mocker: MockerFixture
-) -> None:
-    from anaconda_cli_base.exceptions import register_error_handler
-
-    class _TelTestError(Exception):
-        pass
-
-    @register_error_handler(_TelTestError)
-    def _handle(e: type) -> int:
-        return 99
-
-    import anaconda_cli_base.cli
-
-    @anaconda_cli_base.cli.app.command("tel-fail")
-    def tel_fail() -> None:
-        raise _TelTestError("boom")
-
-    before = mocker.patch("anaconda_cli_base.cli._before_command")
-    after = mocker.patch("anaconda_cli_base.cli._after_command")
-
-    result = invoke_cli(["tel-fail"])
-    assert result.exit_code == 99
-
-    before.assert_called_once()
-    after.assert_called_once()
-    _, kwargs = after.call_args
-    assert kwargs["success"] is False
-    assert isinstance(kwargs["error"], _TelTestError)
-
-
-def test_cli_retry_calls_telemetry_once(
-    invoke_cli: CLIInvoker, mocker: MockerFixture
-) -> None:
-    from anaconda_cli_base.exceptions import register_error_handler
-
-    class _TelRetryError(Exception):
-        pass
-
-    call_count = 0
-
-    @register_error_handler(_TelRetryError)
-    def _handle(e: type) -> int:
-        return -1
-
-    import anaconda_cli_base.cli
-
-    @anaconda_cli_base.cli.app.command("tel-retry")
-    def tel_retry() -> None:
-        nonlocal call_count
-        call_count += 1
-        if call_count < 2:
-            raise _TelRetryError("retry me")
-
-    before = mocker.patch("anaconda_cli_base.cli._before_command")
-    after = mocker.patch("anaconda_cli_base.cli._after_command")
-
-    result = invoke_cli(["tel-retry"])
-    assert result.exit_code == 0
-    assert call_count == 2
-
-    before.assert_called_once()
-    after.assert_called_once()
-
-
-def test_count_calls_increment_counter_with_source(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch
-) -> None:
-    import anaconda_cli_base.telemetry as mod
-
-    monkeypatch.setattr(mod, "_initialized", True)
-    inc = mocker.patch("anaconda_opentelemetry.increment_counter", return_value=True)
-
-    from anaconda_cli_base.telemetry import count
-
-    count("models_downloaded", plugin_name="ai", attributes={"model": "llama3"})
-
-    inc.assert_called_once_with(
-        "models_downloaded",
-        by=1,
-        attributes={"model": "llama3", "source": "anaconda-cli-base", "plugin": "ai"},
-    )
-
-
-def test_count_noop_when_disabled(mocker: MockerFixture) -> None:
-    inc = mocker.patch("anaconda_opentelemetry.increment_counter")
-
-    from anaconda_cli_base.telemetry import count
-
-    count("anything", plugin_name="test-plugin")
-
-    inc.assert_not_called()
-
-
-def test_histogram_calls_record_histogram_with_source_and_plugin(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch
-) -> None:
-    import anaconda_cli_base.telemetry as mod
-
-    monkeypatch.setattr(mod, "_initialized", True)
-    hist = mocker.patch("anaconda_opentelemetry.record_histogram", return_value=True)
-
-    from anaconda_cli_base.telemetry import histogram
-
-    histogram(
-        "download_size_bytes",
-        plugin_name="ai",
-        value=1024.5,
-        attributes={"model": "llama3"},
-    )
-
-    hist.assert_called_once_with(
-        "download_size_bytes",
-        1024.5,
-        attributes={"model": "llama3", "source": "anaconda-cli-base", "plugin": "ai"},
-    )
-
-
-def test_histogram_noop_when_disabled(mocker: MockerFixture) -> None:
-    hist = mocker.patch("anaconda_opentelemetry.record_histogram")
-
-    from anaconda_cli_base.telemetry import histogram
-
-    histogram("anything", plugin_name="test-plugin", value=1.0)
-
-    hist.assert_not_called()
-
-
-def test_log_event_calls_send_event_with_source_and_plugin(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch
-) -> None:
-    import anaconda_cli_base.telemetry as mod
-
-    monkeypatch.setattr(mod, "_initialized", True)
-    send = mocker.patch("anaconda_opentelemetry.signals.send_event", return_value=True)
-
-    from anaconda_cli_base.telemetry import log_event
-
-    log_event(
-        "user started chat",
-        "chat_started",
-        plugin_name="ai",
-        attributes={"mode": "stream"},
-    )
-
-    send.assert_called_once_with(
-        "user started chat",
-        "chat_started",
-        attributes={"mode": "stream", "source": "anaconda-cli-base", "plugin": "ai"},
-    )
-
-
-def test_log_event_noop_when_disabled(mocker: MockerFixture) -> None:
-    send = mocker.patch("anaconda_opentelemetry.signals.send_event")
-
-    from anaconda_cli_base.telemetry import log_event
-
-    log_event("anything", "event", plugin_name="test-plugin")
-
-    send.assert_not_called()
-
-
-def test_traced_yields_noop_span_when_disabled() -> None:
-    from anaconda_cli_base.telemetry import traced, _NoOpSpan
-
-    with traced("some_operation", plugin_name="ai") as span:
-        assert isinstance(span, _NoOpSpan)
-
-
-def test_traced_passes_correct_attributes(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch
-) -> None:
-    import anaconda_cli_base.telemetry as mod
-    from contextlib import contextmanager
-
-    monkeypatch.setattr(mod, "_initialized", True)
-
-    @contextmanager
-    def fake_get_trace(name: str, attributes: Any = None) -> Generator[Any, None, None]:
-        yield mocker.MagicMock()
-
-    get_trace = mocker.patch(
-        "anaconda_opentelemetry.get_trace", side_effect=fake_get_trace
-    )
-
-    from anaconda_cli_base.telemetry import traced
-
-    with traced("models_download", plugin_name="ai", attributes={"model": "llama3"}):
-        pass
-
-    get_trace.assert_called_once_with(
-        "models_download",
-        attributes={"model": "llama3", "source": "anaconda-cli-base", "plugin": "ai"},
-    )
-
-
-def test_traced_yields_noop_on_exception(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch
-) -> None:
-    import anaconda_cli_base.telemetry as mod
-
-    monkeypatch.setattr(mod, "_initialized", True)
-    mocker.patch("anaconda_opentelemetry.get_trace", side_effect=RuntimeError("broken"))
-
-    from anaconda_cli_base.telemetry import traced, _NoOpSpan
-
-    with traced("will_fail", plugin_name="test-plugin") as span:
-        assert isinstance(span, _NoOpSpan)
-
-
-def test_suppress_http_spans_sets_and_resets() -> None:
-    from anaconda_cli_base.telemetry import suppress_http_spans, is_http_suppressed
-
-    assert is_http_suppressed() is False
-
-    with suppress_http_spans():
-        assert is_http_suppressed() is True
-
-    assert is_http_suppressed() is False
-
-
-def test_suppress_http_spans_nests_correctly() -> None:
-    from anaconda_cli_base.telemetry import suppress_http_spans, is_http_suppressed
-
-    with suppress_http_spans():
-        assert is_http_suppressed() is True
+        assert is_http_suppressed() is False
         with suppress_http_spans():
             assert is_http_suppressed() is True
-        assert is_http_suppressed() is True
+        assert is_http_suppressed() is False
 
-    assert is_http_suppressed() is False
+    def test_suppress_http_spans_nests(self) -> None:
+        from anaconda_cli_base.telemetry import suppress_http_spans, is_http_suppressed
 
-
-def test_get_otel_handler_returns_null_handler_when_disabled() -> None:
-    import logging
-
-    from anaconda_cli_base.telemetry import get_otel_handler
-
-    handler = get_otel_handler()
-    assert isinstance(handler, logging.NullHandler)
-
-
-def test_get_otel_handler_returns_logging_handler_when_enabled(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch
-) -> None:
-    import logging
-    import anaconda_cli_base.telemetry as mod
-
-    monkeypatch.setattr(mod, "_initialized", True)
-
-    fake_handler = logging.Handler()
-    mocker.patch(
-        "anaconda_opentelemetry.signals.get_telemetry_logger_handler",
-        return_value=fake_handler,
-    )
-
-    from anaconda_cli_base.telemetry import get_otel_handler
-
-    handler = get_otel_handler()
-    assert handler is fake_handler
-    assert handler.level == logging.WARNING
-
-
-def test_get_otel_handler_respects_custom_level(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch
-) -> None:
-    import logging
-    import anaconda_cli_base.telemetry as mod
-
-    monkeypatch.setattr(mod, "_initialized", True)
-
-    fake_handler = logging.Handler()
-    mocker.patch(
-        "anaconda_opentelemetry.signals.get_telemetry_logger_handler",
-        return_value=fake_handler,
-    )
-
-    from anaconda_cli_base.telemetry import get_otel_handler
-
-    handler = get_otel_handler(level=logging.ERROR)
-    assert handler.level == logging.ERROR
-
-
-def test_get_otel_handler_returns_null_handler_on_import_error(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch
-) -> None:
-    import logging
-    import anaconda_cli_base.telemetry as mod
-
-    monkeypatch.setattr(mod, "_initialized", True)
-    mocker.patch(
-        "anaconda_opentelemetry.signals.get_telemetry_logger_handler",
-        side_effect=ImportError("no module"),
-    )
-
-    from anaconda_cli_base.telemetry import get_otel_handler
-
-    handler = get_otel_handler()
-    assert isinstance(handler, logging.NullHandler)
+        with suppress_http_spans():
+            with suppress_http_spans():
+                assert is_http_suppressed() is True
+            assert is_http_suppressed() is True
+        assert is_http_suppressed() is False

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -17,6 +17,7 @@ def isolate_telemetry(monkeypatch: MonkeyPatch) -> Generator[None, None, None]:
     import anaconda_cli_base.telemetry as mod
 
     monkeypatch.setattr(mod, "_initialized", False)
+    monkeypatch.setattr(mod, "_get_plugin_versions", lambda: {})
     yield
 
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+from typing import Generator, Iterator
+from unittest.mock import call
+
+import pytest
+from pytest import MonkeyPatch
+from pytest_mock import MockerFixture
+
+
+@pytest.fixture(autouse=True)
+def isolate_telemetry(monkeypatch: MonkeyPatch) -> Generator[None, None, None]:
+    import anaconda_cli_base.telemetry as mod
+
+    monkeypatch.setattr(mod, "_initialized", False)
+    yield
+
+
+@pytest.fixture
+def config_toml(tmp_path: Path, monkeypatch: MonkeyPatch) -> Iterator[Path]:
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_file))
+    yield config_file
+
+
+@pytest.fixture
+def telemetry_enabled(monkeypatch: MonkeyPatch, config_toml: Path) -> None:
+    config_toml.write_text(
+        dedent("""\
+            [telemetry]
+            endpoint = "http://localhost:19999"
+            public_endpoint = "http://localhost:19999"
+            skip_internet_check = true
+        """)
+    )
+
+
+@pytest.fixture
+def mock_otel(mocker: MockerFixture) -> dict:
+    """Stub the OTel initialization and recording functions.
+
+    Replaces _ensure_initialized with a simple flag-set so tests exercise
+    _before_command/_after_command logic without requiring anaconda-opentelemetry.
+    """
+    import anaconda_cli_base.telemetry as mod
+
+    mocker.patch(
+        "anaconda_cli_base.telemetry._ensure_initialized",
+        side_effect=lambda: setattr(mod, "_initialized", True),
+    )
+    inc = mocker.patch("anaconda_opentelemetry.increment_counter", return_value=True)
+    hist = mocker.patch("anaconda_opentelemetry.record_histogram", return_value=True)
+    shutdown = mocker.patch("anaconda_cli_base.telemetry._shutdown_telemetry")
+
+    return {
+        "increment_counter": inc,
+        "record_histogram": hist,
+        "shutdown": shutdown,
+    }
+
+
+def test_successful_command_records_metrics(mock_otel: dict) -> None:
+    from anaconda_cli_base.telemetry import _before_command, _after_command
+
+    info = _before_command(["ai", "chat"], "anaconda")
+    assert info is not None
+    assert info.command == "ai chat"
+    assert info.plugin == "ai"
+
+    _after_command(info, success=True)
+
+    mock_otel["record_histogram"].assert_called_once()
+    hist_args = mock_otel["record_histogram"].call_args
+    assert hist_args[0][0] == "cli_command_duration_ms"
+    assert hist_args[0][2]["command"] == "ai chat"
+    assert hist_args[0][2]["source"] == "anaconda-cli-base"
+
+    mock_otel["increment_counter"].assert_called_once_with(
+        "cli_command_invoked",
+        attributes={
+            "command": "ai chat",
+            "plugin": "ai",
+            "source": "anaconda-cli-base",
+        },
+    )
+
+
+def test_failed_command_records_error_metric(mock_otel: dict) -> None:
+    from anaconda_cli_base.telemetry import _before_command, _after_command
+
+    info = _before_command(["ai", "chat"], "anaconda")
+    _after_command(info, success=False, error=RuntimeError("connection timeout"))
+
+    calls = mock_otel["increment_counter"].call_args_list
+    assert len(calls) == 2
+
+    assert calls[0] == call(
+        "cli_command_invoked",
+        attributes={
+            "command": "ai chat",
+            "plugin": "ai",
+            "source": "anaconda-cli-base",
+        },
+    )
+    assert calls[1] == call(
+        "cli_command_errors",
+        attributes={
+            "command": "ai chat",
+            "plugin": "ai",
+            "source": "anaconda-cli-base",
+            "error.type": "RuntimeError",
+        },
+    )
+
+
+def test_telemetry_disabled_when_endpoint_blanked(
+    monkeypatch: MonkeyPatch, config_toml: Path
+) -> None:
+    config_toml.write_text('[telemetry]\nendpoint = ""\n')
+
+    from anaconda_cli_base.telemetry import _is_enabled
+
+    assert _is_enabled() is False
+
+
+def test_telemetry_disabled_by_otel_sdk_disabled(
+    monkeypatch: MonkeyPatch, telemetry_enabled: None
+) -> None:
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+
+    from anaconda_cli_base.telemetry import _before_command
+
+    info = _before_command(["ai", "chat"], "anaconda")
+    assert info is None
+
+
+def test_after_command_noop_when_info_is_none(mock_otel: dict) -> None:
+    from anaconda_cli_base.telemetry import _after_command
+
+    _after_command(None, success=True)
+
+    mock_otel["increment_counter"].assert_not_called()
+    mock_otel["record_histogram"].assert_not_called()
+
+
+def test_shutdown_called_after_command(mock_otel: dict) -> None:
+    from anaconda_cli_base.telemetry import _before_command, _after_command
+
+    info = _before_command(["ai", "chat"], "anaconda")
+    _after_command(info, success=True)
+
+    mock_otel["shutdown"].assert_called_once()
+
+
+def test_duration_is_positive(mock_otel: dict) -> None:
+    from anaconda_cli_base.telemetry import _before_command, _after_command
+    import time
+
+    info = _before_command(["ai", "chat"], "anaconda")
+    time.sleep(0.01)
+    _after_command(info, success=True)
+
+    hist_args = mock_otel["record_histogram"].call_args
+    duration_ms = hist_args[0][1]
+    assert duration_ms >= 10.0
+
+
+def test_noop_span_methods_are_safe() -> None:
+    from anaconda_cli_base.telemetry import _NoOpSpan
+
+    span = _NoOpSpan()
+    span.add_event("test", {"key": "value"})
+    span.add_exception(RuntimeError("boom"))
+    span.set_error_status("error")
+    span.add_attributes({"key": "value"})

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -435,3 +435,71 @@ def test_suppress_http_spans_nests_correctly() -> None:
         assert is_http_suppressed() is True
 
     assert is_http_suppressed() is False
+
+
+def test_get_otel_handler_returns_null_handler_when_disabled() -> None:
+    import logging
+
+    from anaconda_cli_base.telemetry import get_otel_handler
+
+    handler = get_otel_handler()
+    assert isinstance(handler, logging.NullHandler)
+
+
+def test_get_otel_handler_returns_logging_handler_when_enabled(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch
+) -> None:
+    import logging
+    import anaconda_cli_base.telemetry as mod
+
+    monkeypatch.setattr(mod, "_initialized", True)
+
+    fake_handler = logging.Handler()
+    mocker.patch(
+        "anaconda_opentelemetry.signals.get_telemetry_logger_handler",
+        return_value=fake_handler,
+    )
+
+    from anaconda_cli_base.telemetry import get_otel_handler
+
+    handler = get_otel_handler()
+    assert handler is fake_handler
+    assert handler.level == logging.WARNING
+
+
+def test_get_otel_handler_respects_custom_level(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch
+) -> None:
+    import logging
+    import anaconda_cli_base.telemetry as mod
+
+    monkeypatch.setattr(mod, "_initialized", True)
+
+    fake_handler = logging.Handler()
+    mocker.patch(
+        "anaconda_opentelemetry.signals.get_telemetry_logger_handler",
+        return_value=fake_handler,
+    )
+
+    from anaconda_cli_base.telemetry import get_otel_handler
+
+    handler = get_otel_handler(level=logging.ERROR)
+    assert handler.level == logging.ERROR
+
+
+def test_get_otel_handler_returns_null_handler_on_import_error(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch
+) -> None:
+    import logging
+    import anaconda_cli_base.telemetry as mod
+
+    monkeypatch.setattr(mod, "_initialized", True)
+    mocker.patch(
+        "anaconda_opentelemetry.signals.get_telemetry_logger_handler",
+        side_effect=ImportError("no module"),
+    )
+
+    from anaconda_cli_base.telemetry import get_otel_handler
+
+    handler = get_otel_handler()
+    assert isinstance(handler, logging.NullHandler)

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -1,0 +1,241 @@
+"""Integration tests that prove telemetry events arrive at a real OTLP receiver.
+
+These tests use oteltest to spin up a local HTTP OTLP receiver, configure
+the telemetry module to export there, and assert that data actually arrives.
+
+Marked with @pytest.mark.integration — excluded from normal test runs by tox.
+Run with: pytest -m integration
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import time
+
+import pytest
+
+from oteltest.sink import HttpSink
+from oteltest.sink.handler import AccumulatingHandler, Telemetry
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for(telemetry: Telemetry, kind: str, timeout: float = 5.0) -> None:
+    """Poll until at least one request of the given kind arrives."""
+    attr = f"{kind}_requests"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if len(getattr(telemetry, attr)):
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"No {kind} received within {timeout}s")
+
+
+@pytest.fixture(scope="module")
+def otlp_sink():
+    """Module-scoped: start OTLP receiver and initialize telemetry once."""
+    import anaconda_cli_base.telemetry as mod
+
+    port = _free_port()
+    handler = AccumulatingHandler()
+    sink = HttpSink(handler, logging.getLogger("otelsink"), port=port, daemon=True)
+    sink.start()
+    time.sleep(0.3)
+
+    os.environ["ANACONDA_TELEMETRY_ENDPOINT"] = f"http://localhost:{port}"
+    os.environ["ANACONDA_TELEMETRY_ENABLED"] = "true"
+    os.environ.pop("OTEL_SDK_DISABLED", None)
+
+    mod._initialized = False
+    mod._ensure_initialized()
+
+    if not mod._initialized:
+        sink.stop()
+        pytest.skip(
+            "Telemetry failed to initialize (anaconda-opentelemetry not available)"
+        )
+
+    yield handler
+
+    mod._shutdown_telemetry()
+    time.sleep(0.3)
+    sink.stop()
+
+    os.environ.pop("ANACONDA_TELEMETRY_ENDPOINT", None)
+    os.environ.pop("ANACONDA_TELEMETRY_ENABLED", None)
+
+
+@pytest.fixture()
+def otlp(otlp_sink) -> Telemetry:
+    """Per-test access to the shared telemetry accumulator."""
+    return otlp_sink.telemetry
+
+
+pytestmark = pytest.mark.integration
+
+
+def _flush():
+    """Force flush all providers without shutting them down."""
+    from opentelemetry import trace, metrics
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk._logs import LoggerProvider
+    from anaconda_opentelemetry.logging import _AnacondaLogger
+
+    tp = trace.get_tracer_provider()
+    if isinstance(tp, TracerProvider):
+        tp.force_flush(timeout_millis=5000)
+
+    mp = metrics.get_meter_provider()
+    if isinstance(mp, MeterProvider):
+        mp.force_flush(timeout_millis=5000)
+
+    if _AnacondaLogger._instance is not None:
+        lp = _AnacondaLogger._instance._provider
+        if isinstance(lp, LoggerProvider):
+            lp.force_flush(timeout_millis=5000)
+
+
+class TestMetrics:
+    def test_count_delivers_metric(self, otlp: Telemetry) -> None:
+        from anaconda_cli_base.telemetry import count
+
+        count("test_counter", plugin_name="integration", value=3)
+        _flush()
+        _wait_for(otlp, "metric")
+
+        names = set()
+        for req in otlp.metric_requests:
+            for rs in req.pbreq.resource_metrics:
+                for sm in rs.scope_metrics:
+                    for metric in sm.metrics:
+                        names.add(metric.name)
+
+        assert "test_counter" in names
+
+    def test_histogram_delivers_metric(self, otlp: Telemetry) -> None:
+        from anaconda_cli_base.telemetry import histogram
+
+        histogram("test_duration_ms", plugin_name="integration", value=42.5)
+        _flush()
+        _wait_for(otlp, "metric")
+
+        names = set()
+        for req in otlp.metric_requests:
+            for rs in req.pbreq.resource_metrics:
+                for sm in rs.scope_metrics:
+                    for metric in sm.metrics:
+                        names.add(metric.name)
+
+        assert "test_duration_ms" in names
+
+
+class TestLogs:
+    def test_log_event_delivers_log(self, otlp: Telemetry) -> None:
+        from anaconda_cli_base.telemetry import log_event
+
+        log_event(
+            "integration test event",
+            event_name="test_event",
+            plugin_name="integration",
+            attributes={"key": "value"},
+        )
+        _flush()
+        _wait_for(otlp, "log")
+
+        bodies = []
+        for req in otlp.log_requests:
+            for rs in req.pbreq.resource_logs:
+                for sl in rs.scope_logs:
+                    for record in sl.log_records:
+                        bodies.append(record.body.string_value)
+
+        assert "integration test event" in bodies
+
+    def test_otel_log_handler_delivers_log(self, otlp: Telemetry) -> None:
+        from anaconda_cli_base.telemetry import get_otel_handler
+
+        test_logger = logging.getLogger("integration_test_logger")
+        test_logger.addHandler(get_otel_handler(level=logging.WARNING))
+        test_logger.setLevel(logging.WARNING)
+
+        test_logger.warning("handler integration test warning")
+        _flush()
+        _wait_for(otlp, "log")
+
+        bodies = []
+        for req in otlp.log_requests:
+            for rs in req.pbreq.resource_logs:
+                for sl in rs.scope_logs:
+                    for record in sl.log_records:
+                        bodies.append(record.body.string_value)
+
+        assert "handler integration test warning" in bodies
+
+
+class TestTracing:
+    def test_traced_delivers_span(self, otlp: Telemetry) -> None:
+        from anaconda_cli_base.telemetry import traced
+
+        with traced(
+            "test_operation", plugin_name="integration", attributes={"step": "1"}
+        ):
+            time.sleep(0.01)
+
+        _flush()
+        _wait_for(otlp, "trace")
+
+        span_names = set()
+        for req in otlp.trace_requests:
+            for rs in req.pbreq.resource_spans:
+                for ss in rs.scope_spans:
+                    for span in ss.spans:
+                        span_names.add(span.name)
+
+        assert "test_operation" in span_names
+
+
+class TestResourceAttributes:
+    def test_resource_attributes_are_correct(self, otlp: Telemetry) -> None:
+        from anaconda_cli_base.telemetry import count
+
+        count("resource_attr_test", plugin_name="integration")
+        _flush()
+        _wait_for(otlp, "metric")
+
+        resource_attrs = {}
+        for req in otlp.metric_requests:
+            for rs in req.pbreq.resource_metrics:
+                for attr in rs.resource.attributes:
+                    resource_attrs[attr.key] = attr.value
+
+        assert resource_attrs["service.name"].string_value == "anaconda-cli-base"
+        assert resource_attrs["environment"].string_value == "production"
+        assert "platform" in resource_attrs
+        assert len(resource_attrs["platform"].string_value) > 0
+
+
+class TestCLIIntegration:
+    def test_cli_command_delivers_metrics(self, otlp: Telemetry) -> None:
+        from anaconda_cli_base.telemetry import _before_command, _after_command
+
+        info = _before_command(["test", "subcommand"], "anaconda")
+        _after_command(info, success=True)
+        _flush()
+        _wait_for(otlp, "metric")
+
+        names = set()
+        for req in otlp.metric_requests:
+            for rs in req.pbreq.resource_metrics:
+                for sm in rs.scope_metrics:
+                    for metric in sm.metrics:
+                        names.add(metric.name)
+
+        assert "cli_command_duration_ms" in names
+        assert "cli_command_invoked" in names

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -53,10 +53,10 @@ def otlp_sink():
     mod.config.enabled = True
     mod.config.endpoint = f"http://localhost:{port}"
 
-    mod._backend_initialized = False
-    mod._init_backend()
+    mod._initialized = False
+    mod._ensure_initialized()
 
-    if not mod._backend_initialized:
+    if not mod._initialized:
         sink.stop()
         pytest.skip(
             "Telemetry failed to initialize (anaconda-opentelemetry not available)"
@@ -64,7 +64,7 @@ def otlp_sink():
 
     yield handler
 
-    mod.shutdown()
+    mod._shutdown_telemetry()
     time.sleep(0.3)
     sink.stop()
 
@@ -256,9 +256,9 @@ class TestCLIIntegration:
 
 class TestBackendInit:
     def test_multiple_calls_share_single_backend(self, otlp: Telemetry) -> None:
-        from anaconda_cli_base.telemetry import count, is_enabled
+        from anaconda_cli_base.telemetry import count, is_telemetry_enabled
 
-        assert is_enabled()
+        assert is_telemetry_enabled()
 
         count("from_first_call", plugin_name="plugin-a")
         count("from_second_call", plugin_name="plugin-b")

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -27,7 +27,6 @@ def _free_port() -> int:
 
 
 def _wait_for(telemetry: Telemetry, kind: str, timeout: float = 5.0) -> None:
-    """Poll until at least one request of the given kind arrives."""
     attr = f"{kind}_requests"
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -39,7 +38,6 @@ def _wait_for(telemetry: Telemetry, kind: str, timeout: float = 5.0) -> None:
 
 @pytest.fixture(scope="module")
 def otlp_sink():
-    """Module-scoped: start OTLP receiver and initialize telemetry once."""
     import anaconda_cli_base.telemetry as mod
 
     port = _free_port()
@@ -52,10 +50,13 @@ def otlp_sink():
     os.environ["ANACONDA_TELEMETRY_ENABLED"] = "true"
     os.environ.pop("OTEL_SDK_DISABLED", None)
 
-    mod._initialized = False
-    mod._ensure_initialized()
+    mod.config.enabled = True
+    mod.config.endpoint = f"http://localhost:{port}"
 
-    if not mod._initialized:
+    mod._backend_initialized = False
+    mod._init_backend()
+
+    if not mod._backend_initialized:
         sink.stop()
         pytest.skip(
             "Telemetry failed to initialize (anaconda-opentelemetry not available)"
@@ -63,7 +64,7 @@ def otlp_sink():
 
     yield handler
 
-    mod._shutdown_telemetry()
+    mod.shutdown()
     time.sleep(0.3)
     sink.stop()
 
@@ -73,7 +74,6 @@ def otlp_sink():
 
 @pytest.fixture()
 def otlp(otlp_sink) -> Telemetry:
-    """Per-test access to the shared telemetry accumulator."""
     return otlp_sink.telemetry
 
 
@@ -81,7 +81,6 @@ pytestmark = pytest.mark.integration
 
 
 def _flush():
-    """Force flush all providers without shutting them down."""
     from opentelemetry import trace, metrics
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.metrics import MeterProvider
@@ -162,7 +161,8 @@ class TestLogs:
         from anaconda_cli_base.telemetry import get_otel_handler
 
         test_logger = logging.getLogger("integration_test_logger")
-        test_logger.addHandler(get_otel_handler(level=logging.WARNING))
+        handler = get_otel_handler(level=logging.WARNING)
+        test_logger.addHandler(handler)
         test_logger.setLevel(logging.WARNING)
 
         test_logger.warning("handler integration test warning")
@@ -177,6 +177,7 @@ class TestLogs:
                         bodies.append(record.body.string_value)
 
         assert "handler integration test warning" in bodies
+        test_logger.removeHandler(handler)
 
 
 class TestTracing:
@@ -223,10 +224,22 @@ class TestResourceAttributes:
 
 class TestCLIIntegration:
     def test_cli_command_delivers_metrics(self, otlp: Telemetry) -> None:
-        from anaconda_cli_base.telemetry import _before_command, _after_command
+        from anaconda_cli_base.telemetry import _before_command
+        from anaconda_opentelemetry import increment_counter, record_histogram
 
         info = _before_command(["test", "subcommand"], "anaconda")
-        _after_command(info, success=True)
+        assert info is not None
+        duration_ms = (time.perf_counter() - info.start_time) * 1000
+        attrs = {
+            "command": info.command,
+            "plugin": info.plugin,
+            "source": "anaconda-cli-base",
+            "flags": info.flags,
+            "exit_code": 0,
+        }
+        record_histogram("cli_command_duration_ms", duration_ms, attrs)
+        increment_counter("cli_command_invoked", attributes=attrs)
+
         _flush()
         _wait_for(otlp, "metric")
 
@@ -239,3 +252,25 @@ class TestCLIIntegration:
 
         assert "cli_command_duration_ms" in names
         assert "cli_command_invoked" in names
+
+
+class TestBackendInit:
+    def test_multiple_calls_share_single_backend(self, otlp: Telemetry) -> None:
+        from anaconda_cli_base.telemetry import count, is_enabled
+
+        assert is_enabled()
+
+        count("from_first_call", plugin_name="plugin-a")
+        count("from_second_call", plugin_name="plugin-b")
+        _flush()
+        _wait_for(otlp, "metric")
+
+        names = set()
+        for req in otlp.metric_requests:
+            for rs in req.pbreq.resource_metrics:
+                for sm in rs.scope_metrics:
+                    for metric in sm.metrics:
+                        names.add(metric.name)
+
+        assert "from_first_call" in names
+        assert "from_second_call" in names

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -16,8 +16,8 @@ import time
 
 import pytest
 
-from oteltest.sink import HttpSink  # type: ignore[import-not-found,import-untyped]
-from oteltest.sink.handler import AccumulatingHandler, Telemetry  # type: ignore[import-not-found,import-untyped]
+from oteltest.sink import HttpSink
+from oteltest.sink.handler import AccumulatingHandler, Telemetry
 
 
 def _free_port() -> int:

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -16,8 +16,8 @@ import time
 
 import pytest
 
-from oteltest.sink import HttpSink  # type: ignore[import-untyped]
-from oteltest.sink.handler import AccumulatingHandler, Telemetry  # type: ignore[import-untyped]
+from oteltest.sink import HttpSink  # type: ignore[import-not-found,import-untyped]
+from oteltest.sink.handler import AccumulatingHandler, Telemetry  # type: ignore[import-not-found,import-untyped]
 
 
 def _free_port() -> int:

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -16,8 +16,8 @@ import time
 
 import pytest
 
-from oteltest.sink import HttpSink
-from oteltest.sink.handler import AccumulatingHandler, Telemetry
+from oteltest.sink import HttpSink  # type: ignore[import-untyped]
+from oteltest.sink.handler import AccumulatingHandler, Telemetry  # type: ignore[import-untyped]
 
 
 def _free_port() -> int:
@@ -37,7 +37,7 @@ def _wait_for(telemetry: Telemetry, kind: str, timeout: float = 5.0) -> None:
 
 
 @pytest.fixture(scope="module")
-def otlp_sink():
+def otlp_sink():  # type: ignore[no-untyped-def]
     import anaconda_cli_base.telemetry as mod
 
     port = _free_port()
@@ -73,14 +73,14 @@ def otlp_sink():
 
 
 @pytest.fixture()
-def otlp(otlp_sink) -> Telemetry:
+def otlp(otlp_sink) -> Telemetry:  # type: ignore[no-untyped-def]
     return otlp_sink.telemetry
 
 
 pytestmark = pytest.mark.integration
 
 
-def _flush():
+def _flush() -> None:
     from opentelemetry import trace, metrics
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.metrics import MeterProvider
@@ -229,8 +229,10 @@ class TestCLIIntegration:
 
         info = _before_command(["test", "subcommand"], "anaconda")
         assert info is not None
+        from typing import Any
+
         duration_ms = (time.perf_counter() - info.start_time) * 1000
-        attrs = {
+        attrs: dict[str, Any] = {
             "command": info.command,
             "plugin": info.plugin,
             "source": "anaconda-cli-base",


### PR DESCRIPTION
Using [anaconda-opentelemetry](https://github.com/anaconda/anaconda-otel-python) this PR adds

* Automatic telemetry events for ALL CLI commands in any plugin, no work needed by plugin authors
* configuration in config.toml and env var to disable telemetry or avoid sending anaconda-anon-usage tokens, or set a proxy url to reach our otel endpoints
* a new `anaconda_cli_base.telemetry` module providing convenience functions for plugin authors to send more telemetry beyond auto-capture CLI


## What's captured automatically
For every `anaconda <plugin> <command>` invocation:
- cli_command_invoked — counter with command, plugin, source attributes
- cli_command_duration_ms — histogram of execution time
- cli_command_errors — counter with error.type on failure

## For plugin authors
Custom telemetry with zero boilerplate:

```python
from anaconda_cli_base.telemetry import traced, count, histogram
with traced("models_download", plugin_name="ai", attributes={"model": model}) as span:
    result = do_download(model)
    span.add_event("download_complete", {"size_bytes": result.size})
count("models_downloaded", plugin_name="ai")
```

`plugin_name=` should match your registered subcommand name. All functions are safe no-ops when telemetry is disabled.