### PR TITLE
introduce long-running command lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ src/*/_version.py
 
 # Stored tokens (for dev)
 /tokens.json
+
+# Spec-driven development
+.omo/

--- a/README.md
+++ b/README.md
@@ -415,6 +415,39 @@ returns a `NullHandler` — safe to call unconditionally with zero overhead.
 Use `get_otel_handler()` for structured errors/warnings. Use `log_event()` for business events
 that shouldn't appear in developer console output (e.g., `"model_downloaded"`, `"session_started"`).
 
+### Long-running commands
+
+Commands that block indefinitely (e.g., servers) need explicit lifecycle management
+so the process exits cleanly on SIGTERM/SIGINT without hanging on telemetry flush.
+
+```python
+from anaconda_cli_base.lifecycle import long_running, register_shutdown_hook
+
+@app.command()
+@long_running
+def serve():
+    register_shutdown_hook(cleanup_resources)
+    asyncio.run(run_server())
+```
+
+The `@long_running` decorator:
+- Installs SIGTERM/SIGINT handlers that trigger a bounded shutdown sequence
+- Starts a watchdog timer (`WATCHDOG_DEADLINE_SECS = 10`) that force-exits the process if shutdown stalls
+- Calls `shutdown_telemetry(timeout_seconds=2.0)` to flush telemetry within a hard time bound
+
+For signal handlers or manual shutdown paths, use `shutdown_telemetry` directly:
+
+```python
+from anaconda_cli_base.telemetry import shutdown_telemetry
+
+# In a signal handler or cleanup path:
+shutdown_telemetry(timeout_seconds=2.0)
+```
+
+Short-lived commands (the common case) need no changes — telemetry is flushed
+automatically via `_after_command` on every normal CLI exit. The `flush_timeout_ms`
+config (default 500ms) controls the per-command flush bound.
+
 ## Setup for development
 
 Ensure you have `conda` installed.

--- a/README.md
+++ b/README.md
@@ -421,6 +421,28 @@ Commands that block indefinitely (e.g., servers) need explicit lifecycle managem
 so the process exits cleanly on SIGTERM/SIGINT without hanging on telemetry flush.
 
 ```python
+from anaconda_cli_base.lifecycle import long_running
+
+@app.command()
+@long_running
+def serve():
+    asyncio.run(run_server())
+```
+
+The `@long_running` decorator:
+- Installs SIGTERM/SIGINT handlers that trigger a bounded shutdown sequence
+- Starts a watchdog timer (`WATCHDOG_DEADLINE_SECS = 10`) that force-exits the process if shutdown stalls
+- Calls `shutdown_telemetry(timeout_seconds=2.0)` to flush telemetry within a hard time bound
+
+Shutdown hooks are optional, but a blocking server usually wants one. On shutdown the
+decorator flushes telemetry and arms the watchdog, but it does not stop your loop: SIGINT
+unblocks `asyncio.run(...)` on its own (it raises `KeyboardInterrupt`), whereas SIGTERM does
+not. Without a hook to stop the loop, a SIGTERM'd server keeps running until the 10s watchdog
+force-exits it — no hang, but neither prompt nor graceful. Register a hook to unblock the loop
+(close a connection, unblock a stdin reader, signal the loop to stop); hooks run before the
+telemetry flush:
+
+```python
 from anaconda_cli_base.lifecycle import long_running, register_shutdown_hook
 
 @app.command()
@@ -429,11 +451,6 @@ def serve():
     register_shutdown_hook(cleanup_resources)
     asyncio.run(run_server())
 ```
-
-The `@long_running` decorator:
-- Installs SIGTERM/SIGINT handlers that trigger a bounded shutdown sequence
-- Starts a watchdog timer (`WATCHDOG_DEADLINE_SECS = 10`) that force-exits the process if shutdown stalls
-- Calls `shutdown_telemetry(timeout_seconds=2.0)` to flush telemetry within a hard time bound
 
 For signal handlers or manual shutdown paths, use `shutdown_telemetry` directly:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ publish = [
   "wheel"
 ]
 telemetry = [
-  "anaconda-opentelemetry >=1.1.0"
+  "anaconda-opentelemetry >=1.2.0"
 ]
 
 [project.scripts]
@@ -150,7 +150,7 @@ deps =
     oteltest
 conda_deps =
     {[testenv]conda_deps}
-    anaconda-opentelemetry >=1.1.0
+    anaconda-opentelemetry >=1.2.0
 conda_channels =
     {[testenv]conda_channels}
 commands = pytest -m "not integration"
@@ -161,7 +161,7 @@ deps =
     oteltest
 conda_deps =
     {[testenv]conda_deps}
-    anaconda-opentelemetry >=1.1.0
+    anaconda-opentelemetry >=1.2.0
 conda_channels =
     {[testenv]conda_channels}
 commands = pytest -m integration
@@ -178,7 +178,7 @@ deps =
     oteltest
 conda_deps =
     anaconda-auth >=0.11
-    anaconda-opentelemetry >=1.1.0
+    anaconda-opentelemetry >=1.2.0
     pip
 conda_channels =
     anaconda-cloud

--- a/src/anaconda_cli_base/lifecycle.py
+++ b/src/anaconda_cli_base/lifecycle.py
@@ -1,0 +1,121 @@
+"""Long-running command lifecycle management for anaconda-cli-base.
+
+Provides signal handling, shutdown hooks, bounded telemetry flush, and a
+process-exit watchdog for CLI commands that block indefinitely (e.g., servers).
+
+Short-lived commands do not need this module — they exit cleanly via
+``_after_command`` which handles telemetry flush automatically.
+"""
+
+import functools
+import logging
+import os
+import signal
+import threading
+from types import FrameType
+from typing import Any, Callable, List, Optional
+
+from anaconda_cli_base import telemetry
+
+logger = logging.getLogger(__name__)
+
+WATCHDOG_DEADLINE_SECS: float = 10.0
+"""Safety-net timeout. After trigger_shutdown() fires, if the process hasn't
+exited within this many seconds, os._exit(143) forces termination."""
+
+_hooks: List[Callable[[], None]] = []
+_triggered: bool = False
+_trigger_lock = threading.Lock()
+
+
+def register_shutdown_hook(hook: Callable[[], None]) -> None:
+    """Register a callable to run when shutdown is triggered.
+
+    Hooks run in registration order. They should be fast (milliseconds)
+    and non-blocking — use them to set events, close pipes, etc.
+
+    Not idempotent: each call appends another hook. Register a given
+    hook once (typically at startup).
+    """
+    _hooks.append(hook)
+
+
+def trigger_shutdown(signum: Optional[int] = None) -> None:
+    """Trigger the shutdown sequence. Idempotent.
+
+    1. Starts the watchdog timer FIRST (so nothing below can prevent it).
+    2. Runs all registered hooks in order (each wrapped in try/except).
+    3. Calls shutdown_telemetry with a 2-second bound.
+
+    Does NOT call os._exit itself — lets normal unwinding continue.
+    The watchdog fires os._exit(128 + signum) only if unwinding stalls.
+    """
+    global _triggered
+    with _trigger_lock:
+        if _triggered:
+            return
+        _triggered = True
+
+    # Start watchdog FIRST — ordering invariant from anaconda-mcp's design
+    timer = threading.Timer(WATCHDOG_DEADLINE_SECS, _force_exit, args=(signum,))
+    timer.daemon = True
+    timer.start()
+
+    # Run hooks in registration order
+    for hook in _hooks:
+        try:
+            hook()
+        except Exception:
+            logger.debug("Shutdown hook %r failed", hook, exc_info=True)
+
+    try:
+        telemetry.shutdown_telemetry(timeout_seconds=2.0)
+    except Exception:
+        logger.debug("Telemetry shutdown in trigger_shutdown failed", exc_info=True)
+
+
+def _force_exit(signum: Optional[int] = None) -> None:
+    """Last-resort process termination. Fires from the watchdog timer."""
+    os._exit(128 + signum if signum is not None else 143)
+
+
+def long_running(func: Callable) -> Callable:
+    """Decorator marking a CLI command as long-running.
+
+    On invocation, installs SIGTERM and SIGINT handlers that call
+    trigger_shutdown(signum). The original signal behavior (KeyboardInterrupt
+    for SIGINT) is preserved after trigger_shutdown runs.
+
+    Idempotent: re-applying is a no-op. Windows-safe (guards on signal
+    availability).
+    """
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        _install_signal_handlers()
+        return func(*args, **kwargs)
+    return wrapper
+
+
+_handlers_installed: bool = False
+
+
+def _install_signal_handlers() -> None:
+    """Install SIGTERM/SIGINT handlers. Idempotent."""
+    global _handlers_installed
+    if _handlers_installed:
+        return
+
+    def _signal_handler(signum: int, frame: Optional[FrameType]) -> None:
+        trigger_shutdown(signum)
+        # For SIGINT, raise KeyboardInterrupt so normal unwinding proceeds
+        if signum == signal.SIGINT:
+            raise KeyboardInterrupt
+
+    try:
+        if hasattr(signal, "SIGTERM"):
+            signal.signal(signal.SIGTERM, _signal_handler)
+        signal.signal(signal.SIGINT, _signal_handler)
+        _handlers_installed = True
+    except (OSError, ValueError):
+        # Not on main thread or unsupported platform
+        logger.debug("Could not install signal handlers", exc_info=True)

--- a/src/anaconda_cli_base/lifecycle.py
+++ b/src/anaconda_cli_base/lifecycle.py
@@ -89,10 +89,12 @@ def long_running(func: Callable) -> Callable:
     Idempotent: re-applying is a no-op. Windows-safe (guards on signal
     availability).
     """
+
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         _install_signal_handlers()
         return func(*args, **kwargs)
+
     return wrapper
 
 

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -265,7 +265,12 @@ def shutdown_telemetry(*, timeout_seconds: float | None = None) -> None:
         return
     try:
         from anaconda_opentelemetry import shutdown_telemetry as _upstream_shutdown
-        effective_timeout = timeout_seconds if timeout_seconds is not None else config.flush_timeout_ms / 1000.0
+
+        effective_timeout = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else config.flush_timeout_ms / 1000.0
+        )
         _upstream_shutdown(timeout_seconds=effective_timeout)
     except ImportError:
         logger.debug("anaconda-opentelemetry.shutdown_telemetry not available")

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -153,6 +153,12 @@ def _ensure_initialized() -> None:
             otel_config.set_metrics_export_interval_ms(config.export_interval_ms)
             otel_config.set_tracing_export_interval_ms(config.export_interval_ms)
 
+            # Disable the SDK's atexit flush handlers so a killed long-running
+            # command can't hang on teardown; cli-base flushes explicitly instead
+            # (per-command via _after_command, and via the lifecycle watchdog).
+            if hasattr(otel_config, "set_shutdown_on_exit"):
+                otel_config.set_shutdown_on_exit(False)
+
             import platform as platform_mod
 
             service_version = re.sub(r"[^a-zA-Z0-9._-]", ".", __version__)[:30]
@@ -240,48 +246,31 @@ def _after_command(
     except Exception:
         pass
 
-    _shutdown_telemetry()
+    shutdown_telemetry()
 
 
-def _shutdown_telemetry() -> None:
-    """Flush all telemetry and disable atexit handlers to prevent exit hangs."""
+def shutdown_telemetry(*, timeout_seconds: float | None = None) -> None:
+    """Public bounded telemetry shutdown for consumers.
+
+    Flushes all telemetry providers with an optional time bound. No-op when
+    telemetry is disabled. Suitable for signal handlers and other last-resort
+    shutdown paths: the ``_initialized`` guard guarantees ``anaconda_opentelemetry``
+    is already imported, so no module loading happens here.
+
+    Args:
+        timeout_seconds: Maximum seconds to wait for flush. Defaults to
+            config.flush_timeout_ms / 1000.0 when None.
+    """
     if not _initialized:
         return
     try:
-        import atexit
-
-        from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.metrics import MeterProvider
-        from opentelemetry.sdk._logs import LoggerProvider
-        from opentelemetry import trace, metrics
-
-        from anaconda_opentelemetry.logging import _AnacondaLogger
-
-        flush_timeout = config.flush_timeout_ms
-
-        trace_provider = trace.get_tracer_provider()
-        if isinstance(trace_provider, TracerProvider):
-            trace_provider.force_flush(timeout_millis=flush_timeout)
-            if trace_provider._atexit_handler is not None:
-                atexit.unregister(trace_provider._atexit_handler)
-                trace_provider._atexit_handler = None
-
-        meter_provider = metrics.get_meter_provider()
-        if isinstance(meter_provider, MeterProvider):
-            meter_provider.force_flush(timeout_millis=flush_timeout)
-            if meter_provider._atexit_handler is not None:
-                atexit.unregister(meter_provider._atexit_handler)
-                meter_provider._atexit_handler = None
-
-        if _AnacondaLogger._instance is not None:
-            logger_provider = _AnacondaLogger._instance._provider
-            if isinstance(logger_provider, LoggerProvider):
-                logger_provider.force_flush(timeout_millis=flush_timeout)
-                if logger_provider._at_exit_handler is not None:
-                    atexit.unregister(logger_provider._at_exit_handler)
-                    logger_provider._at_exit_handler = None
+        from anaconda_opentelemetry import shutdown_telemetry as _upstream_shutdown
+        effective_timeout = timeout_seconds if timeout_seconds is not None else config.flush_timeout_ms / 1000.0
+        _upstream_shutdown(timeout_seconds=effective_timeout)
+    except ImportError:
+        logger.debug("anaconda-opentelemetry.shutdown_telemetry not available")
     except Exception:
-        pass
+        logger.debug("Telemetry shutdown failed", exc_info=True)
 
 
 def is_telemetry_enabled() -> bool:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,287 @@
+"""Unit tests for the lifecycle module.
+
+NOTE: The test conftest.py sets OTEL_SDK_DISABLED=true, but these tests
+operate at the module-state level and do not actually exercise the OTel
+backend. Real os._exit and threading.Timer are patched out for safety.
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+from typing import Generator, List
+from unittest.mock import MagicMock
+
+import pytest
+from pytest import MonkeyPatch
+from pytest_mock import MockerFixture
+
+import anaconda_cli_base.lifecycle as mod
+
+
+@pytest.fixture(autouse=True)
+def reset_lifecycle(monkeypatch: MonkeyPatch) -> Generator[None, None, None]:
+    """Reset module-level state before every test."""
+    monkeypatch.setattr(mod, "_triggered", False)
+    monkeypatch.setattr(mod, "_handlers_installed", False)
+    monkeypatch.setattr(mod, "_hooks", [])
+    yield
+
+
+@pytest.fixture(autouse=True)
+def safe_force_exit(mocker: MockerFixture) -> MagicMock:
+    """Safety net so os._exit cannot run from tests."""
+    return mocker.patch("anaconda_cli_base.lifecycle.os._exit")
+
+
+@pytest.fixture
+def fake_timer(mocker: MockerFixture) -> MagicMock:
+    """Patch threading.Timer so the watchdog never fires."""
+    return mocker.patch("anaconda_cli_base.lifecycle.threading.Timer")
+
+
+@pytest.fixture
+def mock_shutdown_telemetry(mocker: MockerFixture) -> MagicMock:
+    """Patch the public telemetry shutdown to avoid OTel imports."""
+    return mocker.patch("anaconda_cli_base.telemetry.shutdown_telemetry")
+
+
+class TestRegisterShutdownHook:
+    def test_hooks_run_in_registration_order(
+        self,
+        fake_timer: MagicMock,
+        mock_shutdown_telemetry: MagicMock,
+    ) -> None:
+        order: List[str] = []
+        mod.register_shutdown_hook(lambda: order.append("first"))
+        mod.register_shutdown_hook(lambda: order.append("second"))
+        mod.register_shutdown_hook(lambda: order.append("third"))
+
+        mod.trigger_shutdown()
+
+        assert order == ["first", "second", "third"]
+
+    def test_register_appends_to_hooks_list(self) -> None:
+        def hook() -> None:
+            pass
+
+        assert mod._hooks == []
+        mod.register_shutdown_hook(hook)
+        assert mod._hooks == [hook]
+
+
+class TestTriggerShutdownIdempotency:
+    def test_second_call_is_noop(
+        self,
+        fake_timer: MagicMock,
+        mock_shutdown_telemetry: MagicMock,
+    ) -> None:
+        counter = {"n": 0}
+
+        def hook() -> None:
+            counter["n"] += 1
+
+        mod.register_shutdown_hook(hook)
+
+        mod.trigger_shutdown()
+        mod.trigger_shutdown()
+
+        assert counter["n"] == 1
+        assert fake_timer.call_count == 1
+        assert mock_shutdown_telemetry.call_count == 1
+
+    def test_only_one_watchdog_timer_started(
+        self,
+        fake_timer: MagicMock,
+        mock_shutdown_telemetry: MagicMock,
+    ) -> None:
+        for _ in range(5):
+            mod.trigger_shutdown()
+
+        assert fake_timer.call_count == 1
+        timer_instance = fake_timer.return_value
+        assert timer_instance.start.call_count == 1
+
+
+class TestTriggerShutdownTelemetry:
+    def test_calls_shutdown_telemetry_with_2s_timeout(
+        self,
+        fake_timer: MagicMock,
+        mock_shutdown_telemetry: MagicMock,
+    ) -> None:
+        mod.trigger_shutdown()
+
+        mock_shutdown_telemetry.assert_called_once_with(timeout_seconds=2.0)
+
+    def test_does_not_acquire_telemetry_lock(
+        self,
+        fake_timer: MagicMock,
+        monkeypatch: MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        import anaconda_cli_base.telemetry as tel
+
+        monkeypatch.setattr(tel, "_initialized", True)
+
+        fake_upstream = mocker.MagicMock()
+        fake_upstream.shutdown_telemetry = mocker.MagicMock()
+        monkeypatch.setitem(sys.modules, "anaconda_opentelemetry", fake_upstream)
+
+        fail_lock = mocker.MagicMock()
+        fail_lock.acquire.side_effect = AssertionError(
+            "trigger_shutdown must not acquire telemetry._lock"
+        )
+        fail_lock.__enter__.side_effect = AssertionError(
+            "trigger_shutdown must not enter telemetry._lock context"
+        )
+        monkeypatch.setattr(tel, "_lock", fail_lock)
+
+        mod.trigger_shutdown()
+
+        fail_lock.acquire.assert_not_called()
+        fail_lock.__enter__.assert_not_called()
+
+    def test_hook_exception_does_not_stop_shutdown(
+        self,
+        fake_timer: MagicMock,
+        mock_shutdown_telemetry: MagicMock,
+    ) -> None:
+        ran: List[str] = []
+
+        def boom() -> None:
+            raise RuntimeError("boom")
+
+        def ok() -> None:
+            ran.append("ok")
+
+        mod.register_shutdown_hook(boom)
+        mod.register_shutdown_hook(ok)
+
+        mod.trigger_shutdown()
+
+        assert ran == ["ok"]
+        mock_shutdown_telemetry.assert_called_once_with(timeout_seconds=2.0)
+
+    def test_telemetry_shutdown_exception_swallowed(
+        self,
+        fake_timer: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        mocker.patch(
+            "anaconda_cli_base.telemetry.shutdown_telemetry",
+            side_effect=RuntimeError("upstream blew up"),
+        )
+
+        mod.trigger_shutdown()
+
+    def test_watchdog_timer_started_before_hooks_run(
+        self,
+        fake_timer: MagicMock,
+        mock_shutdown_telemetry: MagicMock,
+    ) -> None:
+        events: List[str] = []
+
+        timer_instance = fake_timer.return_value
+        timer_instance.start.side_effect = lambda: events.append("timer_started")
+
+        def hook() -> None:
+            events.append("hook_ran")
+
+        mod.register_shutdown_hook(hook)
+        mod.trigger_shutdown()
+
+        assert events == ["timer_started", "hook_ran"]
+
+
+class TestLongRunningDecorator:
+    def test_decoration_does_not_install_signal_handlers(
+        self, mocker: MockerFixture
+    ) -> None:
+        signal_signal = mocker.patch("anaconda_cli_base.lifecycle.signal.signal")
+
+        @mod.long_running
+        def cmd() -> str:
+            return "ran"
+
+        assert signal_signal.call_count == 0
+        assert mod._handlers_installed is False
+
+    def test_invocation_installs_signal_handlers(
+        self, mocker: MockerFixture
+    ) -> None:
+        signal_signal = mocker.patch("anaconda_cli_base.lifecycle.signal.signal")
+
+        @mod.long_running
+        def cmd() -> str:
+            return "ran"
+
+        result = cmd()
+
+        assert result == "ran"
+        assert signal_signal.call_count >= 1
+        assert mod._handlers_installed is True
+
+    def test_repeated_invocation_only_installs_once(
+        self, mocker: MockerFixture
+    ) -> None:
+        signal_signal = mocker.patch("anaconda_cli_base.lifecycle.signal.signal")
+
+        @mod.long_running
+        def cmd() -> None:
+            pass
+
+        cmd()
+        first_count = signal_signal.call_count
+        cmd()
+        cmd()
+
+        assert signal_signal.call_count == first_count
+
+    def test_module_import_does_not_register_signals(self) -> None:
+        assert mod._handlers_installed is False
+        assert mod._hooks == []
+        assert mod._triggered is False
+
+    def test_signal_handler_install_failure_is_swallowed(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch(
+            "anaconda_cli_base.lifecycle.signal.signal",
+            side_effect=ValueError("not on main thread"),
+        )
+
+        @mod.long_running
+        def cmd() -> str:
+            return "ran"
+
+        result = cmd()
+        assert result == "ran"
+        assert mod._handlers_installed is False
+
+
+class TestForceExit:
+    @pytest.mark.parametrize(
+        ("signum", "expected_code"),
+        [
+            (signal.SIGTERM, 143),
+            (signal.SIGINT, 130),
+            (None, 143),
+        ],
+    )
+    def test_force_exit_maps_signum_to_exit_code(
+        self,
+        safe_force_exit: MagicMock,
+        signum: int | None,
+        expected_code: int,
+    ) -> None:
+        mod._force_exit(signum)
+
+        safe_force_exit.assert_called_once_with(expected_code)
+
+    def test_force_exit_distinguishes_signum_zero_from_missing(
+        self,
+        safe_force_exit: MagicMock,
+    ) -> None:
+        mod._force_exit(0)
+
+        safe_force_exit.assert_called_once_with(128)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -206,9 +206,7 @@ class TestLongRunningDecorator:
         assert signal_signal.call_count == 0
         assert mod._handlers_installed is False
 
-    def test_invocation_installs_signal_handlers(
-        self, mocker: MockerFixture
-    ) -> None:
+    def test_invocation_installs_signal_handlers(self, mocker: MockerFixture) -> None:
         signal_signal = mocker.patch("anaconda_cli_base.lifecycle.signal.signal")
 
         @mod.long_running

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -14,6 +14,7 @@ invocation with telemetry fully enabled against a local oteltest receiver.
 
 from __future__ import annotations
 
+import sys
 import threading
 from typing import Generator
 
@@ -241,3 +242,104 @@ class TestHttpSuppression:
                 assert is_http_suppressed() is True
             assert is_http_suppressed() is True
         assert is_http_suppressed() is False
+
+
+class TestShutdownDelegation:
+    def test_shutdown_telemetry_public_noop_when_disabled(self) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import shutdown_telemetry
+
+        assert mod._initialized is False
+        shutdown_telemetry()
+        shutdown_telemetry(timeout_seconds=1.0)
+        assert mod._initialized is False
+
+    def test_shutdown_telemetry_delegates_to_upstream(
+        self, monkeypatch: MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import shutdown_telemetry
+
+        monkeypatch.setattr(mod, "_initialized", True)
+
+        fake_upstream_func = mocker.MagicMock()
+        fake_module = mocker.MagicMock()
+        fake_module.shutdown_telemetry = fake_upstream_func
+        monkeypatch.setitem(sys.modules, "anaconda_opentelemetry", fake_module)
+
+        shutdown_telemetry(timeout_seconds=3.5)
+
+        fake_upstream_func.assert_called_once_with(timeout_seconds=3.5)
+
+    def test_shutdown_telemetry_uses_default_timeout_from_config(
+        self, monkeypatch: MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import shutdown_telemetry
+
+        monkeypatch.setattr(mod, "_initialized", True)
+
+        fake_upstream_func = mocker.MagicMock()
+        fake_module = mocker.MagicMock()
+        fake_module.shutdown_telemetry = fake_upstream_func
+        monkeypatch.setitem(sys.modules, "anaconda_opentelemetry", fake_module)
+
+        shutdown_telemetry()
+
+        expected = mod.config.flush_timeout_ms / 1000.0
+        fake_upstream_func.assert_called_once_with(timeout_seconds=expected)
+
+    def test_shutdown_telemetry_fallback_on_import_error(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import shutdown_telemetry
+
+        monkeypatch.setattr(mod, "_initialized", True)
+        monkeypatch.setitem(sys.modules, "anaconda_opentelemetry", None)
+
+        shutdown_telemetry(timeout_seconds=1.0)
+        shutdown_telemetry()
+
+    def test_shutdown_telemetry_swallows_upstream_exception(
+        self, monkeypatch: MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import shutdown_telemetry
+
+        monkeypatch.setattr(mod, "_initialized", True)
+
+        fake_upstream_func = mocker.MagicMock(side_effect=RuntimeError("boom"))
+        fake_module = mocker.MagicMock()
+        fake_module.shutdown_telemetry = fake_upstream_func
+        monkeypatch.setitem(sys.modules, "anaconda_opentelemetry", fake_module)
+
+        shutdown_telemetry(timeout_seconds=1.0)
+
+    def test_shutdown_telemetry_does_not_acquire_init_lock(
+        self, monkeypatch: MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import shutdown_telemetry
+
+        monkeypatch.setattr(mod, "_initialized", True)
+
+        fake_upstream_func = mocker.MagicMock()
+        fake_module = mocker.MagicMock()
+        fake_module.shutdown_telemetry = fake_upstream_func
+        monkeypatch.setitem(sys.modules, "anaconda_opentelemetry", fake_module)
+
+        fail_lock = mocker.MagicMock()
+        fail_lock.acquire.side_effect = AssertionError(
+            "shutdown_telemetry must not acquire _lock"
+        )
+        fail_lock.__enter__.side_effect = AssertionError(
+            "shutdown_telemetry must not enter _lock context"
+        )
+        monkeypatch.setattr(mod, "_lock", fail_lock)
+
+        shutdown_telemetry(timeout_seconds=2.0)
+
+        fake_upstream_func.assert_called_once_with(timeout_seconds=2.0)
+        fail_lock.acquire.assert_not_called()
+        fail_lock.__enter__.assert_not_called()

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -64,7 +64,7 @@ def otlp_sink():  # type: ignore[no-untyped-def]
 
     yield handler
 
-    mod._shutdown_telemetry()
+    mod.shutdown_telemetry()
     time.sleep(0.3)
     sink.stop()
 


### PR DESCRIPTION
See slack thread for context: https://anaconda.slack.com/archives/C0ATM81J2UE/p1780949776540469

This PR uses the `shutdown_on_exit` changes in anaconda-otel-python [here](https://github.com/anaconda/anaconda-otel-python/pull/69) to allow consumers to specify that a command is long-running and manage the shutdown lifecycle manually.