### PR TITLE
Custom attributes available for base command telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,19 @@ def download(model: str):
 The `plugin_name` should match your registered subcommand name (e.g., `"ai"` for `anaconda ai`).
 This ensures custom telemetry correlates with the automatic command metrics in dashboards.
 
+To enrich the automatic command metrics with additional context, use `add_command_attributes()`:
+
+```python
+from anaconda_cli_base.telemetry import add_command_attributes
+
+@app.command()
+def share(channel: str, user: str, role: str):
+    add_command_attributes(role=role, action="share", channel_count=1)
+    # ... execute share operation
+```
+
+These attributes merge into the `cli_command_invoked` and `cli_command_duration_ms` metrics that are automatically collected for every command invocation. If this function takes an attribute key that's already in the attributes, this function's attribute is silently dropped.
+
 All functions are no-ops when telemetry is disabled — they will never raise or affect CLI behavior.
 
 ### Logging handler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,10 @@ module = "rich_click.*"
 ignore_missing_imports = true
 module = "oteltest.*"
 
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
+module = "anaconda_auth.*"
+
 [tool.pytest.ini_options]
 addopts = [
   "--cov=anaconda_cli_base",

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -238,6 +238,7 @@ def _after_command(
 
         custom_attrs = _command_attributes.get() or {}
         for k, v in custom_attrs.items():
+            # key insertion that protects base/pre-existing values
             if k not in attrs:
                 attrs[k] = v
             else:
@@ -403,7 +404,6 @@ def log_event(
     try:
         from anaconda_opentelemetry.signals import send_event
 
-        logger.debug(f"Attributes: {attributes}")
         send_event(body, event_name, attributes=_build_attrs(attributes, plugin_name))
     except Exception:
         pass
@@ -412,17 +412,14 @@ def log_event(
 def add_command_attributes(**attributes: Any) -> None:
     """Add custom attributes to the current command's telemetry.
 
-    These attributes are merged into the command metrics/events when the
-    command completes. Use this to track command-specific context like
-    role, namespace, or other semantic attributes beyond flags.
+    These attributes are merged into the base command metrics when the
+    command completes. Used to add additional attributes to default telemetry
+    without sending an additional telemetry event.
 
     Safe to call multiple times - attributes are merged (later calls override).
-    No-op when telemetry is disabled. Invalid attribute values are filtered.
-    Custom attributes will not override any attributes already set.
-
-    Example:
-        from anaconda_cli_base.telemetry import add_command_attributes
-        add_command_attributes(role="viewer", namespace="myorg", shared_channels=3)
+    Custom attributes will only override previously set custom attributes, not
+    attributes of the base command (set in _after_command). No-op when telemetry
+    is disabled. Invalid attribute values are filtered.
     """
     if not _initialized:
         return

--- a/src/anaconda_cli_base/telemetry.py
+++ b/src/anaconda_cli_base/telemetry.py
@@ -33,6 +33,9 @@ _lock = threading.Lock()
 _initialized = False
 
 _suppress_http: ContextVar[bool] = ContextVar("_suppress_http", default=False)
+_command_attributes: ContextVar[Optional[Dict[str, AttributeValue]]] = ContextVar(
+    "_command_attributes", default=None
+)
 
 
 @lru_cache(maxsize=1)
@@ -233,6 +236,13 @@ def _after_command(
             "exit_code": exit_code if not success else 0,
         }
 
+        custom_attrs = _command_attributes.get() or {}
+        for k, v in custom_attrs.items():
+            if k not in attrs:
+                attrs[k] = v
+            else:
+                logger.debug("Skipping custom attribute key that already exists: %s", k)
+
         record_histogram("cli_command_duration_ms", duration_ms, attrs)
         increment_counter("cli_command_invoked", attributes=attrs)
         if not success:
@@ -245,6 +255,8 @@ def _after_command(
             increment_counter("cli_command_errors", attributes=error_attrs)
     except Exception:
         pass
+    finally:
+        _command_attributes.set({})
 
     shutdown_telemetry()
 
@@ -391,9 +403,44 @@ def log_event(
     try:
         from anaconda_opentelemetry.signals import send_event
 
+        logger.debug(f"Attributes: {attributes}")
         send_event(body, event_name, attributes=_build_attrs(attributes, plugin_name))
     except Exception:
         pass
+
+
+def add_command_attributes(**attributes: Any) -> None:
+    """Add custom attributes to the current command's telemetry.
+
+    These attributes are merged into the command metrics/events when the
+    command completes. Use this to track command-specific context like
+    role, namespace, or other semantic attributes beyond flags.
+
+    Safe to call multiple times - attributes are merged (later calls override).
+    No-op when telemetry is disabled. Invalid attribute values are filtered.
+    Custom attributes will not override any attributes already set.
+
+    Example:
+        from anaconda_cli_base.telemetry import add_command_attributes
+        add_command_attributes(role="viewer", namespace="myorg", shared_channels=3)
+    """
+    if not _initialized:
+        return
+    filtered: Dict[str, AttributeValue] = {}
+    for k, v in attributes.items():
+        if isinstance(v, (str, bool, int, float)):
+            filtered[k] = v
+        elif isinstance(v, (list, tuple)) and all(
+            isinstance(x, (str, bool, int, float)) for x in v
+        ):
+            filtered[k] = list(v)
+        else:
+            logger.debug(
+                "Skipping invalid attribute %s=%r (type: %s)", k, v, type(v).__name__
+            )
+
+    current = _command_attributes.get() or {}
+    _command_attributes.set({**current, **filtered})
 
 
 def _build_attrs(

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -127,6 +127,54 @@ class TestAttrs:
         assert "source" not in original
         assert "source" in result
 
+class TestCustomAttrs:
+    def test_add_command_attributes_stores_valid_attrs(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import add_command_attributes, _command_attributes
+
+        monkeypatch.setattr(mod, "_initialized", True)
+        add_command_attributes(role="viewer", count=5)
+
+        attrs = _command_attributes.get()
+        assert attrs == {"role": "viewer", "count": 5}
+
+    def test_add_command_attributes_does_not_overwrite_base_attrs(
+        self, monkeypatch: MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import add_command_attributes, _before_command, _after_command
+
+        monkeypatch.setattr(mod, "_initialized", True)
+        fake_otel = mocker.MagicMock()
+        monkeypatch.setitem(sys.modules, "anaconda_opentelemetry", fake_otel)
+
+        add_command_attributes(command="fake_command", plugin="fake_plugin", custom="value")
+        info = _before_command(["test", "cmd"], "anaconda")
+        _after_command(info, success=True)
+
+        attrs = fake_otel.record_histogram.call_args[0][2]
+        assert attrs["command"] == "test cmd"
+        assert attrs["plugin"] == "test"
+        assert attrs["custom"] == "value"
+
+    def test_add_command_attributes_filters_invalid_types(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        import anaconda_cli_base.telemetry as mod
+        from anaconda_cli_base.telemetry import (
+            add_command_attributes,
+            _command_attributes,
+        )
+
+        monkeypatch.setattr(mod, "_initialized", True)
+        add_command_attributes(valid="test", invalid={"key": "value"})
+
+        attrs = _command_attributes.get()
+        assert attrs["valid"] == "test"
+        assert "invalid" not in attrs
+
 
 class TestCommandTracking:
     def test_before_command_returns_none_when_disabled(self) -> None:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -127,12 +127,16 @@ class TestAttrs:
         assert "source" not in original
         assert "source" in result
 
+
 class TestCustomAttrs:
     def test_add_command_attributes_stores_valid_attrs(
         self, monkeypatch: MonkeyPatch
     ) -> None:
         import anaconda_cli_base.telemetry as mod
-        from anaconda_cli_base.telemetry import add_command_attributes, _command_attributes
+        from anaconda_cli_base.telemetry import (
+            add_command_attributes,
+            _command_attributes,
+        )
 
         monkeypatch.setattr(mod, "_initialized", True)
         add_command_attributes(role="viewer", count=5)
@@ -144,13 +148,19 @@ class TestCustomAttrs:
         self, monkeypatch: MonkeyPatch, mocker: MockerFixture
     ) -> None:
         import anaconda_cli_base.telemetry as mod
-        from anaconda_cli_base.telemetry import add_command_attributes, _before_command, _after_command
+        from anaconda_cli_base.telemetry import (
+            add_command_attributes,
+            _before_command,
+            _after_command,
+        )
 
         monkeypatch.setattr(mod, "_initialized", True)
         fake_otel = mocker.MagicMock()
         monkeypatch.setitem(sys.modules, "anaconda_opentelemetry", fake_otel)
 
-        add_command_attributes(command="fake_command", plugin="fake_plugin", custom="value")
+        add_command_attributes(
+            command="fake_command", plugin="fake_plugin", custom="value"
+        )
         info = _before_command(["test", "cmd"], "anaconda")
         _after_command(info, success=True)
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -127,12 +127,16 @@ class TestAttrs:
         assert "source" not in original
         assert "source" in result
 
+
 class TestCustomAttrs:
     def test_add_command_attributes_stores_valid_attrs(
         self, monkeypatch: MonkeyPatch
     ) -> None:
         import anaconda_cli_base.telemetry as mod
-        from anaconda_cli_base.telemetry import add_command_attributes, _command_attributes
+        from anaconda_cli_base.telemetry import (
+            add_command_attributes,
+            _command_attributes,
+        )
 
         monkeypatch.setattr(mod, "_initialized", True)
         add_command_attributes(role="viewer", count=5)
@@ -144,13 +148,19 @@ class TestCustomAttrs:
         self, monkeypatch: MonkeyPatch, mocker: MockerFixture
     ) -> None:
         import anaconda_cli_base.telemetry as mod
-        from anaconda_cli_base.telemetry import add_command_attributes, _before_command, _after_command
+        from anaconda_cli_base.telemetry import (
+            add_command_attributes,
+            _before_command,
+            _after_command,
+        )
 
         monkeypatch.setattr(mod, "_initialized", True)
         fake_otel = mocker.MagicMock()
         monkeypatch.setitem(sys.modules, "anaconda_opentelemetry", fake_otel)
 
-        add_command_attributes(command="fake_command", plugin="fake_plugin", custom="value")
+        add_command_attributes(
+            command="fake_command", plugin="fake_plugin", custom="value"
+        )
         info = _before_command(["test", "cmd"], "anaconda")
         _after_command(info, success=True)
 
@@ -172,6 +182,7 @@ class TestCustomAttrs:
         add_command_attributes(valid="test", invalid={"key": "value"})
 
         attrs = _command_attributes.get()
+        assert attrs is not None
         assert attrs["valid"] == "test"
         assert "invalid" not in attrs
 

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -239,6 +239,7 @@ class TestCustomAttributes:
         _wait_for(otlp, "metric")
 
         attrs = {}
+        # very ugly unpacking, necessary for protobuf structure
         for req in otlp.metric_requests:
             for rs in req.pbreq.resource_metrics:
                 for sm in rs.scope_metrics:

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -258,7 +258,9 @@ class TestCustomAttributes:
                                         }
                                         break
 
-        assert attrs, "No matching cli_command_invoked metric found with command='test command'"
+        assert attrs, (
+            "No matching cli_command_invoked metric found with command='test command'"
+        )
         assert attrs["role"].string_value == "viewer"
         assert attrs["namespace"].string_value == "test-org"
         assert attrs["count"].int_value == 42

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -236,6 +236,7 @@ class TestCustomAttributes:
         add_command_attributes(role="viewer", namespace="test-org", count=42)
         _after_command(info, success=True)
 
+        _flush()
         _wait_for(otlp, "metric")
 
         attrs = {}
@@ -257,6 +258,7 @@ class TestCustomAttributes:
                                         }
                                         break
 
+        assert attrs, "No matching cli_command_invoked metric found with command='test command'"
         assert attrs["role"].string_value == "viewer"
         assert attrs["namespace"].string_value == "test-org"
         assert attrs["count"].int_value == 42

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -222,6 +222,45 @@ class TestResourceAttributes:
         assert len(resource_attrs["platform"].string_value) > 0
 
 
+class TestCustomAttributes:
+    def test_custom_command_attributes_included_in_metrics(
+        self, otlp: Telemetry
+    ) -> None:
+        from anaconda_cli_base.telemetry import (
+            add_command_attributes,
+            _before_command,
+            _after_command,
+        )
+
+        info = _before_command(["test", "command"], "anaconda")
+        add_command_attributes(role="viewer", namespace="test-org", count=42)
+        _after_command(info, success=True)
+
+        _wait_for(otlp, "metric")
+
+        attrs = {}
+        for req in otlp.metric_requests:
+            for rs in req.pbreq.resource_metrics:
+                for sm in rs.scope_metrics:
+                    for metric in sm.metrics:
+                        if metric.name == "cli_command_invoked":
+                            for dp in metric.sum.data_points:
+                                for kv in dp.attributes:
+                                    if (
+                                        kv.key == "command"
+                                        and kv.value.string_value == "test command"
+                                    ):
+                                        attrs = {
+                                            attr.key: attr.value
+                                            for attr in dp.attributes
+                                        }
+                                        break
+
+        assert attrs["role"].string_value == "viewer"
+        assert attrs["namespace"].string_value == "test-org"
+        assert attrs["count"].int_value == 42
+
+
 class TestCLIIntegration:
     def test_cli_command_delivers_metrics(self, otlp: Telemetry) -> None:
         from anaconda_cli_base.telemetry import _before_command


### PR DESCRIPTION
Telemetry attributes can now be added to the base command telemetry. Allows for additives to cli command telemetry, without creating a separate telemetry event
- `add_custom_attributes` public function
- Optional custom attributes merged into `attrs` dict in `_after_command`
- Custom attributes do not override anything in `attrs` - keys set by `anaconda-cli-base` are highest priority and immutable from the custom attributes perspective

```python
custom_attrs = {
    'channel': 'dev',
    'namespace': 'myorg',
    'privacy': 'private',
    'user.id': 'xxx'
}
add_command_attributes(**custom_attrs)
```